### PR TITLE
fix: remove non-functional Open in new tab button

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -67,7 +67,6 @@
       <div class="terminal-header">
         <button class="btn btn-sm" id="terminal-back">&larr; Back to Dashboard</button>
         <span class="terminal-title" id="terminal-title">Terminal</span>
-        <button class="btn btn-sm" id="terminal-popout">Open in new tab</button>
       </div>
       <div class="terminal-container" id="terminal-container"></div>
     </div>

--- a/public/js/terminal.js
+++ b/public/js/terminal.js
@@ -489,9 +489,4 @@ document.addEventListener('DOMContentLoaded', () => {
     window.history.back();
   });
 
-  document.getElementById('terminal-popout').addEventListener('click', () => {
-    if (SessionViewer.currentSessionId) {
-      window.open(`/terminal.html?session=${SessionViewer.currentSessionId}`, '_blank', 'width=1000,height=600');
-    }
-  });
 });


### PR DESCRIPTION
## Summary

Removes the "Open in new tab" button from the session viewer overlay — it referenced a `terminal.html` page that doesn't exist.

## Files changed
- `public/index.html` — Removed button element
- `public/js/terminal.js` — Removed click handler

🤖 Generated with [Claude Code](https://claude.com/claude-code)