### PR TITLE
feat: add linting, type checking, README badges, and Makefile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: CI
 
 on:
+  push:
+    branches: [main]
   pull_request:
     branches: [main]
 
@@ -9,6 +11,45 @@ permissions:
   pull-requests: write
 
 jobs:
+  lint:
+    name: Lint & Format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install ruff
+        run: pip install ruff>=0.8.0
+
+      - name: Ruff lint
+        run: ruff check .
+
+      - name: Ruff format check
+        run: ruff format --check .
+
+  type-check:
+    name: Type Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run mypy
+        run: mypy server/
+
   unit-tests:
     name: Unit Tests (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,35 @@
+.DEFAULT_GOAL := help
+PYTHON := python
+PORT := 3000
+
+.PHONY: help up down test lint format typecheck check clean
+
+help: ## Show this help
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2}'
+
+up: ## Start the server (port 3000)
+	uvicorn server.main:app --port $(PORT) --reload
+
+down: ## Stop the server
+	@pkill -f "uvicorn server.main:app" 2>/dev/null && echo "Server stopped" || echo "Server not running"
+
+test: ## Run all tests
+	$(PYTHON) -m pytest tests/ -v
+
+lint: ## Run ruff linter and format check
+	ruff check .
+	ruff format --check .
+
+format: ## Auto-format code with ruff
+	ruff check --fix .
+	ruff format .
+
+typecheck: ## Run mypy type checking
+	mypy server/
+
+check: lint typecheck test ## Run all checks (lint + typecheck + test)
+
+clean: ## Remove build artifacts and caches
+	rm -rf __pycache__ .pytest_cache .mypy_cache .ruff_cache reports/
+	find . -path ./.venv -prune -o -type d -name __pycache__ -print -exec rm -rf {} +
+	find . -path ./.venv -prune -o -type f -name '*.pyc' -print -delete

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Claude Code Command Center
 
+[![CI](https://github.com/amahpour/claude-code-command-center/actions/workflows/ci.yml/badge.svg)](https://github.com/amahpour/claude-code-command-center/actions/workflows/ci.yml)
+[![Python 3.12+](https://img.shields.io/badge/python-3.12%2B-blue.svg)](https://www.python.org/downloads/)
+[![License: MIT](https://img.shields.io/github/license/amahpour/claude-code-command-center)](LICENSE)
+[![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
+[![mypy](https://img.shields.io/badge/type--checked-mypy-blue.svg)](https://mypy-lang.org/)
+
 A web-based command center for monitoring and managing multiple Claude Code sessions in real-time.
 
 ![Dashboard](docs/dashboard.png)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,31 @@ dev = [
     "pytest-asyncio>=0.21.0",
     "httpx>=0.24.0",
     "playwright>=1.40.0",
+    "ruff>=0.8.0",
+    "mypy>=1.13.0",
 ]
+
+[tool.ruff]
+target-version = "py312"
+line-length = 120
+
+[tool.ruff.lint]
+select = ["E", "F", "W", "I", "UP", "B", "SIM"]
+ignore = [
+    "SIM105",  # contextlib.suppress — stylistic
+    "SIM117",  # nested with — often clearer in tests
+    "SIM114",  # combine if branches — stylistic
+    "E501",    # line length — handled by formatter
+]
+
+[tool.mypy]
+python_version = "3.12"
+warn_unused_configs = true
+disallow_untyped_defs = false
+check_untyped_defs = true
+ignore_missing_imports = true
+no_implicit_reexport = false
+warn_return_any = false
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,5 @@ pytest-asyncio>=0.21.0
 httpx>=0.24.0
 playwright>=1.40.0
 pytest-cov>=4.1.0
+ruff>=0.8.0
+mypy>=1.13.0

--- a/scripts/hook-handler.py
+++ b/scripts/hook-handler.py
@@ -7,8 +7,8 @@ Must NEVER block Claude Code — exits silently on any error.
 
 import json
 import sys
-import urllib.request
 import urllib.error
+import urllib.request
 
 SERVER_URL = "http://localhost:3000/api/hooks"
 TIMEOUT = 5
@@ -38,8 +38,7 @@ def main():
         )
         urllib.request.urlopen(req, timeout=TIMEOUT)
 
-    except (json.JSONDecodeError, urllib.error.URLError, urllib.error.HTTPError,
-            OSError, TimeoutError, Exception):
+    except (json.JSONDecodeError, urllib.error.URLError, urllib.error.HTTPError, OSError, TimeoutError, Exception):
         # Never block Claude Code — exit silently on any error
         pass
 

--- a/server/db.py
+++ b/server/db.py
@@ -2,7 +2,7 @@
 
 import json
 import os
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 import aiosqlite
 
@@ -106,7 +106,14 @@ async def _create_tables(db: aiosqlite.Connection):
     """)
 
     # Add columns that may not exist in older databases
-    for col, col_type in [("session_name", "TEXT"), ("effort_level", "TEXT"), ("ticket_id", "TEXT"), ("display_name", "TEXT"), ("display_name_locked", "INTEGER DEFAULT 0"), ("last_activity_preview", "TEXT")]:
+    for col, col_type in [
+        ("session_name", "TEXT"),
+        ("effort_level", "TEXT"),
+        ("ticket_id", "TEXT"),
+        ("display_name", "TEXT"),
+        ("display_name_locked", "INTEGER DEFAULT 0"),
+        ("last_activity_preview", "TEXT"),
+    ]:
         try:
             await db.execute(f"ALTER TABLE sessions ADD COLUMN {col} {col_type}")
         except Exception:
@@ -129,23 +136,23 @@ async def _create_tables(db: aiosqlite.Connection):
 
 # --- Session CRUD ---
 
+
 async def create_session(
     session_id: str,
     project_path: str | None = None,
     model: str | None = None,
     task_description: str | None = None,
-) -> dict:
+) -> dict | None:
     """Create a new session record."""
     db = await get_db()
-    now = datetime.now(timezone.utc).isoformat()
+    now = datetime.now(UTC).isoformat()
     project_name = os.path.basename(project_path) if project_path else None
 
     await db.execute(
         """INSERT INTO sessions (id, project_path, project_name, model,
            task_description, status, started_at, last_activity_at, created_at, updated_at)
            VALUES (?, ?, ?, ?, ?, 'idle', ?, ?, ?, ?)""",
-        (session_id, project_path, project_name, model,
-         task_description, now, now, now, now),
+        (session_id, project_path, project_name, model, task_description, now, now, now, now),
     )
     await db.commit()
     return await get_session(session_id)
@@ -157,13 +164,11 @@ async def update_session(session_id: str, **kwargs) -> dict | None:
     if not kwargs:
         return await get_session(session_id)
 
-    kwargs["updated_at"] = datetime.now(timezone.utc).isoformat()
+    kwargs["updated_at"] = datetime.now(UTC).isoformat()
     set_clause = ", ".join(f"{k} = ?" for k in kwargs)
     values = list(kwargs.values()) + [session_id]
 
-    await db.execute(
-        f"UPDATE sessions SET {set_clause} WHERE id = ?", values
-    )
+    await db.execute(f"UPDATE sessions SET {set_clause} WHERE id = ?", values)
     await db.commit()
     return await get_session(session_id)
 
@@ -224,6 +229,7 @@ async def get_completed_sessions(limit: int = 50, offset: int = 0) -> list[dict]
 
 # --- Events ---
 
+
 async def add_event(
     session_id: str,
     event_type: str,
@@ -239,7 +245,7 @@ async def add_event(
         (session_id, event_type, tool_name, payload_json),
     )
     await db.commit()
-    return cursor.lastrowid
+    return cursor.lastrowid or 0
 
 
 async def get_session_events(session_id: str, limit: int = 100) -> list[dict]:
@@ -258,6 +264,7 @@ async def get_session_events(session_id: str, limit: int = 100) -> list[dict]:
 
 # --- Transcripts ---
 
+
 async def add_transcript(
     session_id: str,
     role: str,
@@ -268,13 +275,13 @@ async def add_transcript(
 ) -> int:
     """Add a transcript entry and update FTS index."""
     db = await get_db()
-    ts = timestamp or datetime.now(timezone.utc).isoformat()
+    ts = timestamp or datetime.now(UTC).isoformat()
     cursor = await db.execute(
         """INSERT INTO transcripts (session_id, source_file, role, content, token_count, timestamp)
            VALUES (?, ?, ?, ?, ?, ?)""",
         (session_id, source_file, role, content, token_count, ts),
     )
-    rowid = cursor.lastrowid
+    rowid = cursor.lastrowid or 0
 
     # Update FTS index
     await db.execute(
@@ -285,9 +292,7 @@ async def add_transcript(
     return rowid
 
 
-async def get_session_transcripts(
-    session_id: str, limit: int = 200, offset: int = 0
-) -> list[dict]:
+async def get_session_transcripts(session_id: str, limit: int = 200, offset: int = 0) -> list[dict]:
     """Get the latest N transcripts for a session, returned in chronological order."""
     db = await get_db()
     # Subquery gets the latest `limit` rows, outer query re-orders ASC for display
@@ -322,6 +327,7 @@ async def search_transcripts(query: str, limit: int = 50) -> list[dict]:
 
 # --- Analytics ---
 
+
 async def get_analytics_summary() -> dict:
     """Get overall analytics summary."""
     db = await get_db()
@@ -337,7 +343,7 @@ async def get_analytics_summary() -> dict:
         FROM sessions
     """)
     row = await cursor.fetchone()
-    summary = dict(row)
+    summary = dict(row) if row else {}
 
     # Today's cost
     cursor = await db.execute("""
@@ -346,7 +352,8 @@ async def get_analytics_summary() -> dict:
         WHERE date(created_at) = date('now')
     """)
     today = await cursor.fetchone()
-    summary["today_cost"] = today["today_cost"]
+    if today:
+        summary["today_cost"] = today["today_cost"]
 
     return summary
 
@@ -372,6 +379,7 @@ async def get_analytics_daily(days: int = 30) -> list[dict]:
 
 
 # --- Settings ---
+
 
 async def get_setting(key: str) -> str | None:
     """Get a single setting value by key."""

--- a/server/hooks.py
+++ b/server/hooks.py
@@ -5,7 +5,7 @@ import json
 import logging
 import os
 import subprocess
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 from server import db
 
@@ -74,7 +74,7 @@ async def process_hook_event(event_data: dict) -> dict | None:
         logger.warning("Hook event missing session_id: %s", event_type)
         return None
 
-    now = datetime.now(timezone.utc).isoformat()
+    now = datetime.now(UTC).isoformat()
     project_path = event_data.get("cwd") or event_data.get("project_path")
     session = await db.get_session(session_id)
 
@@ -95,7 +95,7 @@ async def process_hook_event(event_data: dict) -> dict | None:
 
     # Always update project info from cwd if we have it and session is missing it
     base_updates: dict = {"last_activity_at": now}
-    if project_path and not session.get("project_name"):
+    if project_path and session and not session.get("project_name"):
         base_updates["project_path"] = project_path
         base_updates["project_name"] = project_path.rsplit("/", 1)[-1] if "/" in project_path else project_path
         git_branch = _extract_git_branch(project_path)
@@ -142,10 +142,7 @@ async def process_hook_event(event_data: dict) -> dict | None:
                 base_updates["context_usage_percent"] = (event_data["context_tokens"] / max_ctx) * 100
         session = await db.update_session(session_id, **base_updates)
 
-    elif event_type == "SubagentStart":
-        session = await db.update_session(session_id, **base_updates)
-
-    elif event_type == "SubagentStop":
+    elif event_type == "SubagentStart" or event_type == "SubagentStop":
         session = await db.update_session(session_id, **base_updates)
 
     elif event_type == "Notification":
@@ -172,7 +169,7 @@ async def _check_stale_sessions():
         try:
             await asyncio.sleep(60)
             sessions = await db.get_all_active_sessions()
-            now = datetime.now(timezone.utc)
+            now = datetime.now(UTC)
             for session in sessions:
                 if session["status"] in ("completed", "stale"):
                     continue
@@ -182,7 +179,7 @@ async def _check_stale_sessions():
                 try:
                     last_dt = datetime.fromisoformat(last_activity.replace("Z", "+00:00"))
                     if last_dt.tzinfo is None:
-                        last_dt = last_dt.replace(tzinfo=timezone.utc)
+                        last_dt = last_dt.replace(tzinfo=UTC)
                     diff = (now - last_dt).total_seconds()
                     if diff > 300:  # 5 minutes
                         updated = await db.update_session(session["id"], status="stale")

--- a/server/main.py
+++ b/server/main.py
@@ -5,27 +5,28 @@ from contextlib import asynccontextmanager
 from pathlib import Path
 
 from fastapi import FastAPI, Request
-from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 from starlette.middleware.base import BaseHTTPMiddleware
-from starlette.responses import Response
+
+from server.db import close_db, init_db
+from server.hooks import set_update_callback, start_stale_checker, stop_stale_checker
+from server.routes.api import router as api_router
+from server.routes.ws import broadcast_session_update
+from server.routes.ws import router as ws_router
+from server.watcher import start_watcher, stop_watcher
 
 
 class NoCacheStaticMiddleware(BaseHTTPMiddleware):
     """Disable caching for static files during development."""
+
     async def dispatch(self, request: Request, call_next):
         response = await call_next(request)
-        if request.url.path.endswith(('.js', '.css', '.html')):
+        if request.url.path.endswith((".js", ".css", ".html")):
             response.headers["Cache-Control"] = "no-cache, no-store, must-revalidate"
             response.headers["Pragma"] = "no-cache"
             response.headers["Expires"] = "0"
         return response
 
-from server.db import init_db, close_db
-from server.hooks import start_stale_checker, stop_stale_checker, set_update_callback
-from server.watcher import start_watcher, stop_watcher
-from server.routes.api import router as api_router
-from server.routes.ws import router as ws_router, broadcast_session_update
 
 logging.basicConfig(level=logging.INFO)
 

--- a/server/pr_lookup.py
+++ b/server/pr_lookup.py
@@ -32,7 +32,8 @@ def _get_github_token(host: str = "github.com") -> str | None:
     gh_config = os.path.expanduser("~/.config/gh/hosts.yml")
     if os.path.isfile(gh_config):
         try:
-            import yaml
+            import yaml  # type: ignore[import-untyped]
+
             with open(gh_config) as f:
                 hosts = yaml.safe_load(f)
             if hosts and host in hosts:
@@ -123,8 +124,7 @@ async def find_pr_url(project_path: str, branch: str) -> str | None:
         else:
             return await _find_gitlab_mr(remote, branch)
     except Exception:
-        logger.debug("PR lookup failed for %s/%s branch %s",
-                     remote["owner"], remote["repo"], branch, exc_info=True)
+        logger.debug("PR lookup failed for %s/%s branch %s", remote["owner"], remote["repo"], branch, exc_info=True)
         return None
 
 
@@ -134,7 +134,7 @@ async def _find_github_pr(remote: dict, branch: str) -> str | None:
     owner, repo = remote["owner"], remote["repo"]
     api_host = f"api.{remote['host']}" if remote["host"] == "github.com" else remote["host"]
     url = f"https://{api_host}/repos/{owner}/{repo}/pulls"
-    params = {"head": f"{owner}:{branch}", "state": "open", "per_page": 1}
+    params: dict[str, str | int] = {"head": f"{owner}:{branch}", "state": "open", "per_page": 1}
 
     headers = {"Accept": "application/vnd.github+json"}
     token = _get_github_token(remote["host"])
@@ -156,7 +156,7 @@ async def _find_gitlab_mr(remote: dict, branch: str) -> str | None:
     client = _get_client()
     project_id = quote(remote["full_path"], safe="")
     url = f"https://{remote['host']}/api/v4/projects/{project_id}/merge_requests"
-    params = {"source_branch": branch, "state": "opened", "per_page": 1}
+    params: dict[str, str | int] = {"source_branch": branch, "state": "opened", "per_page": 1}
 
     headers = {}
     token = _get_gitlab_token()

--- a/server/routes/api.py
+++ b/server/routes/api.py
@@ -13,6 +13,7 @@ router = APIRouter(prefix="/api")
 
 class HookEvent(BaseModel):
     """Incoming hook event from hook-handler.py."""
+
     model_config = {"extra": "allow", "populate_by_name": True}
 
     event_type: str | None = None
@@ -46,9 +47,9 @@ _UNSET = object()
 
 class SessionPatch(BaseModel):
     model_config = {"extra": "forbid"}
-    ticket_id: str | None = _UNSET
-    display_name: str | None = _UNSET
-    display_name_locked: bool | None = _UNSET
+    ticket_id: str | None = _UNSET  # type: ignore[assignment]
+    display_name: str | None = _UNSET  # type: ignore[assignment]
+    display_name_locked: bool | None = _UNSET  # type: ignore[assignment]
 
 
 @router.get("/health")
@@ -163,11 +164,12 @@ async def patch_session(session_id: str, req: SessionPatch):
     if req.display_name is not _UNSET:
         updates["display_name"] = req.display_name or None
     if req.display_name_locked is not _UNSET:
-        updates["display_name_locked"] = 1 if req.display_name_locked else 0
+        updates["display_name_locked"] = 1 if req.display_name_locked else 0  # type: ignore[assignment]
     if not updates:
         return {"session": session}
     updated = await db.update_session(session_id, **updates)
     from server.routes.ws import broadcast_session_update
+
     if updated:
         await broadcast_session_update(updated)
     return {"session": updated}
@@ -177,6 +179,7 @@ async def patch_session(session_id: str, req: SessionPatch):
 async def browse_directory(path: str = Query("~")):
     """List directories for the folder picker."""
     import os
+
     resolved = os.path.expanduser(path)
     if not os.path.isdir(resolved):
         raise HTTPException(status_code=400, detail="Not a directory")
@@ -189,8 +192,8 @@ async def browse_directory(path: str = Query("~")):
             if os.path.isdir(full):
                 entries.append({"name": name, "path": full, "type": "dir"})
         return {"path": resolved, "entries": entries}
-    except PermissionError:
-        raise HTTPException(status_code=403, detail="Permission denied")
+    except PermissionError as e:
+        raise HTTPException(status_code=403, detail="Permission denied") from e
 
 
 @router.post("/sessions/new")
@@ -198,7 +201,7 @@ async def new_session(req: NewSessionRequest):
     """Launch a new Claude Code session (disabled — see GitHub issue)."""
     raise HTTPException(
         status_code=501,
-        detail="New Session launching is temporarily disabled. Start Claude Code from your terminal instead — it will appear on the dashboard automatically via hooks."
+        detail="New Session launching is temporarily disabled. Start Claude Code from your terminal instead — it will appear on the dashboard automatically via hooks.",
     )
 
 
@@ -209,9 +212,10 @@ async def stop_session(session_id: str):
     if not session:
         raise HTTPException(status_code=404, detail="Session not found")
     from server.terminal import stop_session as terminal_stop
+
     try:
         await terminal_stop(session_id)
         await db.update_session(session_id, status="completed")
         return {"status": "ok"}
     except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e))
+        raise HTTPException(status_code=500, detail=str(e)) from e

--- a/server/routes/ws.py
+++ b/server/routes/ws.py
@@ -43,11 +43,16 @@ async def dashboard_ws(websocket: WebSocket):
     try:
         # Send initial state
         from server.db import get_all_active_sessions
+
         sessions = await get_all_active_sessions()
-        await websocket.send_text(json.dumps({
-            "type": "initial_state",
-            "sessions": sessions,
-        }))
+        await websocket.send_text(
+            json.dumps(
+                {
+                    "type": "initial_state",
+                    "sessions": sessions,
+                }
+            )
+        )
 
         # Keep connection alive, handle pings
         while True:
@@ -78,10 +83,14 @@ async def terminal_ws(websocket: WebSocket, session_id: str):
 
         pty_fd = await attach_session(session_id)
         if pty_fd is None:
-            await websocket.send_text(json.dumps({
-                "type": "error",
-                "message": f"No terminal found for session {session_id}",
-            }))
+            await websocket.send_text(
+                json.dumps(
+                    {
+                        "type": "error",
+                        "message": f"No terminal found for session {session_id}",
+                    }
+                )
+            )
             await websocket.close()
             return
 
@@ -121,10 +130,14 @@ async def terminal_ws(websocket: WebSocket, session_id: str):
     except Exception as e:
         logger.exception("Terminal WebSocket error for session %s", session_id)
         try:
-            await websocket.send_text(json.dumps({
-                "type": "error",
-                "message": str(e),
-            }))
+            await websocket.send_text(
+                json.dumps(
+                    {
+                        "type": "error",
+                        "message": str(e),
+                    }
+                )
+            )
         except Exception:
             pass
     finally:
@@ -139,6 +152,7 @@ def _read_pty_safe(fd) -> bytes | None:
     """Read from a PTY file descriptor safely."""
     import os
     import select
+
     try:
         r, _, _ = select.select([fd], [], [], 0.1)
         if r:
@@ -151,6 +165,7 @@ def _read_pty_safe(fd) -> bytes | None:
 def _write_pty_safe(fd, data: bytes):
     """Write to a PTY file descriptor safely."""
     import os
+
     try:
         os.write(fd, data)
     except (OSError, ValueError):

--- a/server/terminal.py
+++ b/server/terminal.py
@@ -39,25 +39,19 @@ async def launch_session(project_dir: str, initial_prompt: str | None = None) ->
     claude_cmd = f"cd '{project_dir}' && claude"
 
     loop = asyncio.get_event_loop()
-    await loop.run_in_executor(None, lambda: _run_tmux(
-        "new-session", "-d", "-s", tmux_name, "-x", "200", "-y", "50",
-        claude_cmd
-    ))
+    await loop.run_in_executor(
+        None, lambda: _run_tmux("new-session", "-d", "-s", tmux_name, "-x", "200", "-y", "50", claude_cmd)
+    )
 
     # Accept the trust dialog (sends Enter to confirm "Yes, I trust this folder")
     await asyncio.sleep(2)
-    await loop.run_in_executor(None, lambda: _run_tmux(
-        "send-keys", "-t", tmux_name, "Enter", check=False
-    ))
+    await loop.run_in_executor(None, lambda: _run_tmux("send-keys", "-t", tmux_name, "Enter", check=False))
 
     # Wait for Claude to start, then send the prompt if provided
     if initial_prompt:
         await asyncio.sleep(3)
         escaped = initial_prompt.replace("'", "'\\''")
-        await loop.run_in_executor(None, lambda: _run_tmux(
-            "send-keys", "-t", tmux_name, escaped, "Enter",
-            check=False
-        ))
+        await loop.run_in_executor(None, lambda: _run_tmux("send-keys", "-t", tmux_name, escaped, "Enter", check=False))
 
     _session_tmux_map[session_id] = tmux_name
     logger.info("Launched tmux session %s for session %s in %s", tmux_name, session_id, project_dir)
@@ -84,11 +78,13 @@ async def attach_session(session_id: str) -> int | None:
     # Use a PTY pair to pipe tmux I/O
     master_fd, slave_fd = os.openpty()
 
-    loop = asyncio.get_event_loop()
     try:
         # Start a process that connects tmux to our PTY
-        proc = await asyncio.create_subprocess_exec(
-            "tmux", "attach-session", "-t", tmux_name,
+        await asyncio.create_subprocess_exec(
+            "tmux",
+            "attach-session",
+            "-t",
+            tmux_name,
             stdin=slave_fd,
             stdout=slave_fd,
             stderr=slave_fd,
@@ -101,7 +97,7 @@ async def attach_session(session_id: str) -> int | None:
 
         return master_fd
 
-    except Exception as e:
+    except Exception:
         logger.exception("Failed to attach to tmux session %s", tmux_name)
         os.close(master_fd)
         os.close(slave_fd)
@@ -133,14 +129,10 @@ async def stop_session(session_id: str):
     loop = asyncio.get_event_loop()
     try:
         # Send Ctrl+C first
-        await loop.run_in_executor(None, lambda: _run_tmux(
-            "send-keys", "-t", tmux_name, "C-c", check=False
-        ))
+        await loop.run_in_executor(None, lambda: _run_tmux("send-keys", "-t", tmux_name, "C-c", check=False))
         await asyncio.sleep(1)
         # Kill the session
-        await loop.run_in_executor(None, lambda: _run_tmux(
-            "kill-session", "-t", tmux_name, check=False
-        ))
+        await loop.run_in_executor(None, lambda: _run_tmux("kill-session", "-t", tmux_name, check=False))
     except (subprocess.TimeoutExpired, FileNotFoundError):
         pass
 
@@ -160,10 +152,12 @@ async def list_tmux_sessions() -> list[dict]:
     """List all tmux sessions that belong to the command center."""
     loop = asyncio.get_event_loop()
     try:
-        result = await loop.run_in_executor(None, lambda: _run_tmux(
-            "list-sessions", "-F", "#{session_name}:#{session_created}:#{session_attached}",
-            check=False
-        ))
+        result = await loop.run_in_executor(
+            None,
+            lambda: _run_tmux(
+                "list-sessions", "-F", "#{session_name}:#{session_created}:#{session_attached}", check=False
+            ),
+        )
         if result.returncode != 0:
             return []
 
@@ -172,11 +166,13 @@ async def list_tmux_sessions() -> list[dict]:
             if not line or not line.startswith("cccc-"):
                 continue
             parts = line.split(":", 2)
-            sessions.append({
-                "tmux_name": parts[0],
-                "created": parts[1] if len(parts) > 1 else None,
-                "attached": parts[2] if len(parts) > 2 else "0",
-            })
+            sessions.append(
+                {
+                    "tmux_name": parts[0],
+                    "created": parts[1] if len(parts) > 1 else None,
+                    "attached": parts[2] if len(parts) > 2 else "0",
+                }
+            )
         return sessions
 
     except (subprocess.TimeoutExpired, FileNotFoundError):

--- a/server/watcher.py
+++ b/server/watcher.py
@@ -32,6 +32,7 @@ async def _save_file_positions():
     """Persist file positions to DB."""
     await db.set_setting("file_positions", json.dumps(_file_positions))
 
+
 # Debounce tracking
 _debounce_tasks: dict[str, asyncio.Task] = {}
 DEBOUNCE_SECONDS = 1.0
@@ -93,8 +94,9 @@ def _parse_jsonl_entry(line: str) -> dict | None:
         if not content:
             content = data.get("content", "")
         # Skip system XML tags
-        if isinstance(content, str) and (content.startswith("<command-") or
-                content.startswith("<local-command") or content.startswith("<system-")):
+        if isinstance(content, str) and (
+            content.startswith("<command-") or content.startswith("<local-command") or content.startswith("<system-")
+        ):
             return None
         # Handle tool results embedded in user entries
         tool_result = data.get("toolUseResult")
@@ -243,9 +245,8 @@ def _extract_content(content) -> str | None:
                     parts.append(f"[Result] {text}")
         return "\n".join(parts) if parts else None
 
-    if isinstance(content, dict):
-        if content.get("type") == "text":
-            return content.get("text")
+    if isinstance(content, dict) and content.get("type") == "text":
+        return content.get("text")
 
     return str(content) if content else None
 
@@ -277,10 +278,10 @@ def _generate_auto_title(task_description: str, git_branch: str | None = None) -
         branch = git_branch
         for prefix in ("feature/", "feat/", "fix/", "bugfix/", "hotfix/", "chore/", "refactor/"):
             if branch.lower().startswith(prefix):
-                branch = branch[len(prefix):]
+                branch = branch[len(prefix) :]
                 break
         # Strip ticket IDs (e.g., "PROJ-42-" or "CIT-357-")
-        branch = re.sub(r'^[A-Z]+-\d+-', '', branch)
+        branch = re.sub(r"^[A-Z]+-\d+-", "", branch)
         if branch:
             # Convert kebab-case to title case
             words = branch.replace("-", " ").replace("_", " ").split()
@@ -338,7 +339,7 @@ def _extract_activity_preview(entries: list[dict]) -> str | None:
         # Plain assistant text — take first sentence
         if entry.get("role") == "assistant" and content and "[Tool: " not in content:
             # First sentence or first 80 chars
-            sentence = re.split(r'[.!?\n]', content)[0].strip()
+            sentence = re.split(r"[.!?\n]", content)[0].strip()
             if sentence:
                 return sentence[:80] + ("..." if len(sentence) > 80 else "")
 
@@ -384,7 +385,7 @@ async def _process_file_changes(file_path: str):
     last_pos = _file_positions.get(file_path, 0)
 
     try:
-        with open(file_path, "r", encoding="utf-8", errors="replace") as f:
+        with open(file_path, encoding="utf-8", errors="replace") as f:
             f.seek(last_pos)
             new_lines = f.readlines()
             _file_positions[file_path] = f.tell()
@@ -434,8 +435,7 @@ async def _process_file_changes(file_path: str):
         if entry["role"] == "user" and first_user_message is None and entry["content"]:
             # Skip command/meta/system messages as task descriptions
             c = entry["content"]
-            if (not c.startswith("<") and not c.startswith("{") and not c.startswith("[")
-                    and len(c) > 5):
+            if not c.startswith("<") and not c.startswith("{") and not c.startswith("[") and len(c) > 5:
                 first_user_message = c[:200]
         # Use latest usage snapshot (each assistant message reports current context size)
         if entry.get("usage"):
@@ -521,6 +521,7 @@ async def _process_file_changes(file_path: str):
         # Broadcast to dashboard clients
         try:
             from server.routes.ws import broadcast_session_update
+
             updated = await db.get_session(session_id)
             if updated:
                 await broadcast_session_update(updated)
@@ -556,7 +557,7 @@ async def start_watcher():
         return
 
     try:
-        from watchfiles import awatch, Change
+        from watchfiles import Change, awatch
 
         async def _watch():
             try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,1 @@
 """Shared test fixtures."""
-
-import pytest

--- a/tests/e2e/test_dashboard.py
+++ b/tests/e2e/test_dashboard.py
@@ -4,7 +4,6 @@ These tests start a real server and use a browser to verify the UI.
 Run with: pytest tests/e2e/ -v
 """
 
-import asyncio
 import multiprocessing
 import time
 
@@ -17,7 +16,9 @@ SERVER_URL = f"http://localhost:{SERVER_PORT}"
 def _run_server():
     """Run the server in a separate process."""
     import uvicorn
+
     from server.main import app
+
     uvicorn.run(app, host="127.0.0.1", port=SERVER_PORT, log_level="warning")
 
 
@@ -36,6 +37,7 @@ def server():
 def pw_browser(server):
     """Launch a Playwright browser for the module."""
     from playwright.sync_api import sync_playwright
+
     with sync_playwright() as p:
         browser = p.chromium.launch(headless=True)
         yield browser

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -1,11 +1,11 @@
 """Tests for the REST API endpoints."""
 
 import pytest
-from httpx import AsyncClient, ASGITransport
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
 
 import server.db as db
 from server.routes.api import router
-from fastapi import FastAPI
 
 # Create a test app with just the API router
 test_app = FastAPI()
@@ -84,12 +84,15 @@ async def test_get_transcript_not_found(client: AsyncClient):
 
 
 async def test_receive_hook(client: AsyncClient):
-    resp = await client.post("/api/hooks", json={
-        "event_type": "SessionStart",
-        "session_id": "hook-1",
-        "cwd": "/tmp/myproject",
-        "model": "opus",
-    })
+    resp = await client.post(
+        "/api/hooks",
+        json={
+            "event_type": "SessionStart",
+            "session_id": "hook-1",
+            "cwd": "/tmp/myproject",
+            "model": "opus",
+        },
+    )
     assert resp.status_code == 200
     data = resp.json()
     assert data["status"] == "ok"
@@ -97,9 +100,12 @@ async def test_receive_hook(client: AsyncClient):
 
 
 async def test_receive_hook_no_session_id(client: AsyncClient):
-    resp = await client.post("/api/hooks", json={
-        "event_type": "SessionStart",
-    })
+    resp = await client.post(
+        "/api/hooks",
+        json={
+            "event_type": "SessionStart",
+        },
+    )
     assert resp.status_code == 200
     assert resp.json()["status"] == "ignored"
 
@@ -159,10 +165,13 @@ async def test_get_settings_empty(client: AsyncClient):
 
 
 async def test_update_settings(client: AsyncClient):
-    resp = await client.put("/api/settings", json={
-        "jira_project_keys": ["PROJ", "DEV"],
-        "jira_server_url": "https://jira.example.com",
-    })
+    resp = await client.put(
+        "/api/settings",
+        json={
+            "jira_project_keys": ["PROJ", "DEV"],
+            "jira_server_url": "https://jira.example.com",
+        },
+    )
     assert resp.status_code == 200
     settings = resp.json()["settings"]
     assert settings["jira_project_keys"] == ["PROJ", "DEV"]
@@ -206,7 +215,9 @@ async def test_patch_session_no_updates(client: AsyncClient):
 
 
 async def test_browse_directory(client: AsyncClient):
-    import tempfile, os
+    import os
+    import tempfile
+
     with tempfile.TemporaryDirectory() as d:
         os.makedirs(os.path.join(d, "subdir"))
         with open(os.path.join(d, "file.txt"), "w") as f:
@@ -222,7 +233,9 @@ async def test_browse_directory(client: AsyncClient):
 
 
 async def test_browse_hidden_files_excluded(client: AsyncClient):
-    import tempfile, os
+    import os
+    import tempfile
+
     with tempfile.TemporaryDirectory() as d:
         os.makedirs(os.path.join(d, ".hidden"))
         os.makedirs(os.path.join(d, "visible"))
@@ -240,17 +253,20 @@ async def test_browse_invalid_path(client: AsyncClient):
 
 async def test_browse_permission_denied(client: AsyncClient):
     from unittest.mock import patch
-    with patch("os.listdir", side_effect=PermissionError):
-        with patch("os.path.isdir", return_value=True):
-            resp = await client.get("/api/browse?path=/root")
-            assert resp.status_code == 403
+
+    with patch("os.listdir", side_effect=PermissionError), patch("os.path.isdir", return_value=True):
+        resp = await client.get("/api/browse?path=/root")
+        assert resp.status_code == 403
 
 
 async def test_new_session_disabled(client: AsyncClient):
-    resp = await client.post("/api/sessions/new", json={
-        "project_dir": "/tmp/proj",
-        "prompt": "hello",
-    })
+    resp = await client.post(
+        "/api/sessions/new",
+        json={
+            "project_dir": "/tmp/proj",
+            "prompt": "hello",
+        },
+    )
     assert resp.status_code == 501
 
 
@@ -271,7 +287,8 @@ async def test_patch_session_unlock(client: AsyncClient):
 
 async def test_stop_session_api(client: AsyncClient):
     await db.create_session("stop-1")
-    from unittest.mock import patch, AsyncMock
+    from unittest.mock import AsyncMock, patch
+
     with patch("server.terminal.stop_session", new_callable=AsyncMock):
         resp = await client.post("/api/sessions/stop-1/stop")
         assert resp.status_code == 200
@@ -285,7 +302,8 @@ async def test_stop_session_not_found(client: AsyncClient):
 
 async def test_stop_session_error(client: AsyncClient):
     await db.create_session("stop-err")
-    from unittest.mock import patch, AsyncMock
+    from unittest.mock import AsyncMock, patch
+
     with patch("server.terminal.stop_session", new_callable=AsyncMock, side_effect=Exception("tmux error")):
         resp = await client.post("/api/sessions/stop-err/stop")
         assert resp.status_code == 500

--- a/tests/unit/test_db.py
+++ b/tests/unit/test_db.py
@@ -1,7 +1,9 @@
 """Tests for the database layer."""
 
-import pytest
 from unittest.mock import patch
+
+import pytest
+
 import server.db as db
 
 
@@ -16,9 +18,7 @@ async def setup_db():
 async def test_tables_created():
     """Tables should exist after init."""
     conn = await db.get_db()
-    cursor = await conn.execute(
-        "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name"
-    )
+    cursor = await conn.execute("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name")
     tables = [row[0] for row in await cursor.fetchall()]
     assert "sessions" in tables
     assert "events" in tables
@@ -26,9 +26,7 @@ async def test_tables_created():
 
 
 async def test_create_session():
-    session = await db.create_session(
-        "sess-1", project_path="/home/user/myproject", model="opus"
-    )
+    session = await db.create_session("sess-1", project_path="/home/user/myproject", model="opus")
     assert session["id"] == "sess-1"
     assert session["project_name"] == "myproject"
     assert session["model"] == "opus"
@@ -188,6 +186,7 @@ async def test_get_db_without_init():
 def test_get_db_path_default():
     """Test _get_db_path returns default path."""
     import os
+
     with patch.dict(os.environ, {}, clear=True):
         path = db._get_db_path()
         assert "data.db" in path
@@ -196,13 +195,16 @@ def test_get_db_path_default():
 def test_get_db_path_from_env():
     """Test _get_db_path respects env override."""
     import os
+
     with patch.dict(os.environ, {"CCCC_DB_PATH": "/tmp/test.db"}):
         assert db._get_db_path() == "/tmp/test.db"
 
 
 async def test_init_db_with_file_path():
     """Test init_db creates directory for file-based DB."""
-    import tempfile, os
+    import os
+    import tempfile
+
     await db.close_db()
     with tempfile.TemporaryDirectory() as d:
         path = os.path.join(d, "subdir", "test.db")

--- a/tests/unit/test_hooks.py
+++ b/tests/unit/test_hooks.py
@@ -2,10 +2,11 @@
 
 import asyncio
 import subprocess
-from datetime import datetime, timezone, timedelta
-from unittest.mock import patch, MagicMock, AsyncMock
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+
 import server.db as db
 from server.hooks import process_hook_event
 
@@ -18,12 +19,14 @@ async def setup_db():
 
 
 async def test_session_start():
-    result = await process_hook_event({
-        "event_type": "SessionStart",
-        "session_id": "sess-1",
-        "cwd": "/home/user/myproject",
-        "model": "opus",
-    })
+    result = await process_hook_event(
+        {
+            "event_type": "SessionStart",
+            "session_id": "sess-1",
+            "cwd": "/home/user/myproject",
+            "model": "opus",
+        }
+    )
     assert result is not None
     assert result["id"] == "sess-1"
     assert result["project_name"] == "myproject"
@@ -32,138 +35,176 @@ async def test_session_start():
 
 
 async def test_pre_tool_use():
-    await process_hook_event({
-        "event_type": "SessionStart",
-        "session_id": "sess-2",
-        "cwd": "/tmp/test",
-    })
-    result = await process_hook_event({
-        "event_type": "PreToolUse",
-        "session_id": "sess-2",
-        "tool_name": "Read",
-    })
+    await process_hook_event(
+        {
+            "event_type": "SessionStart",
+            "session_id": "sess-2",
+            "cwd": "/tmp/test",
+        }
+    )
+    result = await process_hook_event(
+        {
+            "event_type": "PreToolUse",
+            "session_id": "sess-2",
+            "tool_name": "Read",
+        }
+    )
     assert result["status"] == "working"
 
 
 async def test_post_tool_use():
-    await process_hook_event({
-        "event_type": "SessionStart",
-        "session_id": "sess-3",
-        "cwd": "/tmp/test",
-    })
-    await process_hook_event({
-        "event_type": "PreToolUse",
-        "session_id": "sess-3",
-        "tool_name": "Write",
-    })
-    result = await process_hook_event({
-        "event_type": "PostToolUse",
-        "session_id": "sess-3",
-        "tool_name": "Write",
-    })
+    await process_hook_event(
+        {
+            "event_type": "SessionStart",
+            "session_id": "sess-3",
+            "cwd": "/tmp/test",
+        }
+    )
+    await process_hook_event(
+        {
+            "event_type": "PreToolUse",
+            "session_id": "sess-3",
+            "tool_name": "Write",
+        }
+    )
+    result = await process_hook_event(
+        {
+            "event_type": "PostToolUse",
+            "session_id": "sess-3",
+            "tool_name": "Write",
+        }
+    )
     # PostToolUse doesn't change status, just updates activity
     assert result is not None
 
 
 async def test_stop_event():
-    await process_hook_event({
-        "event_type": "SessionStart",
-        "session_id": "sess-4",
-        "cwd": "/tmp/test",
-    })
-    await process_hook_event({
-        "event_type": "PreToolUse",
-        "session_id": "sess-4",
-    })
-    result = await process_hook_event({
-        "event_type": "Stop",
-        "session_id": "sess-4",
-        "cost_usd": 0.05,
-        "input_tokens": 1000,
-        "output_tokens": 500,
-    })
+    await process_hook_event(
+        {
+            "event_type": "SessionStart",
+            "session_id": "sess-4",
+            "cwd": "/tmp/test",
+        }
+    )
+    await process_hook_event(
+        {
+            "event_type": "PreToolUse",
+            "session_id": "sess-4",
+        }
+    )
+    result = await process_hook_event(
+        {
+            "event_type": "Stop",
+            "session_id": "sess-4",
+            "cost_usd": 0.05,
+            "input_tokens": 1000,
+            "output_tokens": 500,
+        }
+    )
     assert result["status"] == "idle"
     assert result["cost_usd"] == 0.05
     assert result["input_tokens"] == 1000
 
 
 async def test_session_end():
-    await process_hook_event({
-        "event_type": "SessionStart",
-        "session_id": "sess-5",
-        "cwd": "/tmp/test",
-    })
-    result = await process_hook_event({
-        "event_type": "SessionEnd",
-        "session_id": "sess-5",
-    })
+    await process_hook_event(
+        {
+            "event_type": "SessionStart",
+            "session_id": "sess-5",
+            "cwd": "/tmp/test",
+        }
+    )
+    result = await process_hook_event(
+        {
+            "event_type": "SessionEnd",
+            "session_id": "sess-5",
+        }
+    )
     assert result["status"] == "completed"
     assert result["ended_at"] is not None
 
 
 async def test_notification_event():
-    await process_hook_event({
-        "event_type": "SessionStart",
-        "session_id": "sess-6",
-        "cwd": "/tmp/test",
-    })
-    result = await process_hook_event({
-        "event_type": "Notification",
-        "session_id": "sess-6",
-        "message": "Waiting for permission to write file",
-    })
+    await process_hook_event(
+        {
+            "event_type": "SessionStart",
+            "session_id": "sess-6",
+            "cwd": "/tmp/test",
+        }
+    )
+    result = await process_hook_event(
+        {
+            "event_type": "Notification",
+            "session_id": "sess-6",
+            "message": "Waiting for permission to write file",
+        }
+    )
     assert result["status"] == "waiting"
     # Notification should NOT overwrite task_description
     assert result.get("task_description") is None
 
 
 async def test_subagent_events():
-    await process_hook_event({
-        "event_type": "SessionStart",
-        "session_id": "sess-7",
-        "cwd": "/tmp/test",
-    })
-    result = await process_hook_event({
-        "event_type": "SubagentStart",
-        "session_id": "sess-7",
-    })
+    await process_hook_event(
+        {
+            "event_type": "SessionStart",
+            "session_id": "sess-7",
+            "cwd": "/tmp/test",
+        }
+    )
+    result = await process_hook_event(
+        {
+            "event_type": "SubagentStart",
+            "session_id": "sess-7",
+        }
+    )
     assert result is not None
 
-    result = await process_hook_event({
-        "event_type": "SubagentStop",
-        "session_id": "sess-7",
-    })
+    result = await process_hook_event(
+        {
+            "event_type": "SubagentStop",
+            "session_id": "sess-7",
+        }
+    )
     assert result is not None
 
 
 async def test_unknown_event_creates_session():
-    result = await process_hook_event({
-        "event_type": "SomeNewEvent",
-        "session_id": "sess-8",
-    })
+    result = await process_hook_event(
+        {
+            "event_type": "SomeNewEvent",
+            "session_id": "sess-8",
+        }
+    )
     assert result is not None
     session = await db.get_session("sess-8")
     assert session is not None
 
 
 async def test_missing_session_id():
-    result = await process_hook_event({
-        "event_type": "SessionStart",
-    })
+    result = await process_hook_event(
+        {
+            "event_type": "SessionStart",
+        }
+    )
     assert result is None
 
 
 async def test_events_recorded():
-    await process_hook_event({
-        "event_type": "SessionStart",
-        "session_id": "sess-9",
-        "cwd": "/tmp/test",
-    })
-    await process_hook_event({
-        "event_type": "PreToolUse",
-        "session_id": "sess-9",
-        "tool_name": "Bash",
-    })
+    await process_hook_event(
+        {
+            "event_type": "SessionStart",
+            "session_id": "sess-9",
+            "cwd": "/tmp/test",
+        }
+    )
+    await process_hook_event(
+        {
+            "event_type": "PreToolUse",
+            "session_id": "sess-9",
+            "tool_name": "Bash",
+        }
+    )
     events = await db.get_session_events("sess-9")
     assert len(events) == 2
     types = [e["event_type"] for e in events]
@@ -174,12 +215,12 @@ async def test_events_recorded():
 async def test_stale_session_detection():
     """Test that sessions with old activity are marked stale."""
     await db.create_session("stale-1")
-    old_time = (datetime.now(timezone.utc) - timedelta(minutes=10)).isoformat()
+    old_time = (datetime.now(UTC) - timedelta(minutes=10)).isoformat()
     await db.update_session("stale-1", status="idle", last_activity_at=old_time)
 
     # Manually run the check logic
     sessions = await db.get_all_active_sessions()
-    now = datetime.now(timezone.utc)
+    now = datetime.now(UTC)
     for session in sessions:
         if session["status"] in ("completed", "stale"):
             continue
@@ -187,7 +228,7 @@ async def test_stale_session_detection():
         if last:
             last_dt = datetime.fromisoformat(last.replace("Z", "+00:00"))
             if last_dt.tzinfo is None:
-                last_dt = last_dt.replace(tzinfo=timezone.utc)
+                last_dt = last_dt.replace(tzinfo=UTC)
             diff = (now - last_dt).total_seconds()
             if diff > 300:
                 await db.update_session(session["id"], status="stale")
@@ -197,17 +238,21 @@ async def test_stale_session_detection():
 
 
 async def test_stop_with_context_tracking():
-    await process_hook_event({
-        "event_type": "SessionStart",
-        "session_id": "ctx-1",
-        "cwd": "/tmp/test",
-    })
-    result = await process_hook_event({
-        "event_type": "Stop",
-        "session_id": "ctx-1",
-        "context_tokens": 50000,
-        "context_max": 200000,
-    })
+    await process_hook_event(
+        {
+            "event_type": "SessionStart",
+            "session_id": "ctx-1",
+            "cwd": "/tmp/test",
+        }
+    )
+    result = await process_hook_event(
+        {
+            "event_type": "Stop",
+            "session_id": "ctx-1",
+            "context_tokens": 50000,
+            "context_max": 200000,
+        }
+    )
     assert result["context_tokens"] == 50000
     assert result["context_usage_percent"] == 25.0
 
@@ -215,17 +260,20 @@ async def test_stop_with_context_tracking():
 async def test_git_branch_extraction():
     """Test that git branch is extracted on SessionStart."""
     with patch("server.hooks._extract_git_branch", return_value="feature/test"):
-        result = await process_hook_event({
-            "event_type": "SessionStart",
-            "session_id": "git-1",
-            "cwd": "/tmp/test",
-        })
+        result = await process_hook_event(
+            {
+                "event_type": "SessionStart",
+                "session_id": "git-1",
+                "cwd": "/tmp/test",
+            }
+        )
         assert result["git_branch"] == "feature/test"
 
 
 async def test_notify_update_with_callback():
     """Test that _notify_update calls the callback."""
-    from server.hooks import set_update_callback, _notify_update
+    from server.hooks import _notify_update, set_update_callback
+
     callback = AsyncMock()
     set_update_callback(callback)
     try:
@@ -237,7 +285,8 @@ async def test_notify_update_with_callback():
 
 async def test_notify_update_without_callback():
     """Test that _notify_update is no-op without callback."""
-    from server.hooks import set_update_callback, _notify_update
+    from server.hooks import _notify_update, set_update_callback
+
     set_update_callback(None)
     await _notify_update({"id": "test"})  # Should not raise
 
@@ -245,17 +294,27 @@ async def test_notify_update_without_callback():
 def test_read_effort_level_success():
     """Test reading effort level from settings file."""
     from server.hooks import _read_effort_level
-    with patch("builtins.open", MagicMock(return_value=MagicMock(
-        __enter__=lambda s: s, __exit__=MagicMock(return_value=False),
-        read=MagicMock(return_value='{"effortLevel": "high"}')
-    ))):
-        with patch("json.load", return_value={"effortLevel": "high"}):
-            assert _read_effort_level() == "high"
+
+    with (
+        patch(
+            "builtins.open",
+            MagicMock(
+                return_value=MagicMock(
+                    __enter__=lambda s: s,
+                    __exit__=MagicMock(return_value=False),
+                    read=MagicMock(return_value='{"effortLevel": "high"}'),
+                )
+            ),
+        ),
+        patch("json.load", return_value={"effortLevel": "high"}),
+    ):
+        assert _read_effort_level() == "high"
 
 
 def test_read_effort_level_file_not_found():
     """Test reading effort level when settings file doesn't exist."""
     from server.hooks import _read_effort_level
+
     with patch("builtins.open", side_effect=FileNotFoundError):
         assert _read_effort_level() is None
 
@@ -263,6 +322,7 @@ def test_read_effort_level_file_not_found():
 def test_extract_git_branch_success():
     """Test git branch extraction from working directory."""
     from server.hooks import _extract_git_branch
+
     mock_result = MagicMock(returncode=0, stdout="feature/my-branch\n")
     with patch("subprocess.run", return_value=mock_result):
         assert _extract_git_branch("/tmp/test") == "feature/my-branch"
@@ -271,6 +331,7 @@ def test_extract_git_branch_success():
 def test_extract_git_branch_failure():
     """Test git branch extraction when git fails."""
     from server.hooks import _extract_git_branch
+
     mock_result = MagicMock(returncode=1, stdout="")
     with patch("subprocess.run", return_value=mock_result):
         assert _extract_git_branch("/tmp/test") is None
@@ -279,12 +340,14 @@ def test_extract_git_branch_failure():
 def test_extract_git_branch_no_dir():
     """Test git branch extraction with no directory."""
     from server.hooks import _extract_git_branch
+
     assert _extract_git_branch(None) is None
 
 
 def test_extract_git_branch_timeout():
     """Test git branch extraction when subprocess times out."""
     from server.hooks import _extract_git_branch
+
     with patch("subprocess.run", side_effect=subprocess.TimeoutExpired("git", 5)):
         assert _extract_git_branch("/tmp/test") is None
 
@@ -293,41 +356,50 @@ async def test_session_start_with_effort_level():
     """Test that effort level is read on new session creation."""
     with patch("server.hooks._extract_git_branch", return_value=None):
         with patch("server.hooks._read_effort_level", return_value="low"):
-            result = await process_hook_event({
-                "event_type": "SessionStart",
-                "session_id": "effort-1",
-                "cwd": "/tmp/test",
-            })
+            result = await process_hook_event(
+                {
+                    "event_type": "SessionStart",
+                    "session_id": "effort-1",
+                    "cwd": "/tmp/test",
+                }
+            )
             assert result["effort_level"] == "low"
 
 
 async def test_cache_tokens_in_stop():
     """Test that cache_tokens are recorded in Stop events."""
-    await process_hook_event({
-        "event_type": "SessionStart",
-        "session_id": "cache-1",
-        "cwd": "/tmp/test",
-    })
-    result = await process_hook_event({
-        "event_type": "Stop",
-        "session_id": "cache-1",
-        "cache_tokens": 5000,
-    })
+    await process_hook_event(
+        {
+            "event_type": "SessionStart",
+            "session_id": "cache-1",
+            "cwd": "/tmp/test",
+        }
+    )
+    result = await process_hook_event(
+        {
+            "event_type": "Stop",
+            "session_id": "cache-1",
+            "cache_tokens": 5000,
+        }
+    )
     assert result["cache_tokens"] == 5000
 
 
 async def test_process_hook_broadcasts_update():
     """Test that process_hook_event calls _notify_update."""
     from server.hooks import set_update_callback
+
     callback = AsyncMock()
     set_update_callback(callback)
     try:
         with patch("server.hooks._extract_git_branch", return_value=None):
-            await process_hook_event({
-                "event_type": "SessionStart",
-                "session_id": "broadcast-1",
-                "cwd": "/tmp/test",
-            })
+            await process_hook_event(
+                {
+                    "event_type": "SessionStart",
+                    "session_id": "broadcast-1",
+                    "cwd": "/tmp/test",
+                }
+            )
             assert callback.call_count >= 1
     finally:
         set_update_callback(None)
@@ -337,19 +409,21 @@ async def test_project_path_update_on_existing_session():
     """Test that project info is set from cwd when session lacks it."""
     with patch("server.hooks._extract_git_branch", return_value=None):
         await db.create_session("proj-update-1")
-        result = await process_hook_event({
-            "event_type": "PreToolUse",
-            "session_id": "proj-update-1",
-            "cwd": "/home/user/myproject",
-        })
+        result = await process_hook_event(
+            {
+                "event_type": "PreToolUse",
+                "session_id": "proj-update-1",
+                "cwd": "/home/user/myproject",
+            }
+        )
         assert result["project_name"] == "myproject"
         assert result["project_path"] == "/home/user/myproject"
 
 
 def test_start_and_stop_stale_checker():
     """Test starting and stopping the stale checker."""
-    from server.hooks import start_stale_checker, stop_stale_checker
     import server.hooks as hooks_mod
+    from server.hooks import start_stale_checker, stop_stale_checker
 
     with patch("asyncio.create_task") as mock_create:
         mock_task = MagicMock()
@@ -367,27 +441,29 @@ def test_start_and_stop_stale_checker():
 async def test_event_field_alias():
     """Test that 'event' field works as alias for 'event_type'."""
     with patch("server.hooks._extract_git_branch", return_value=None):
-        result = await process_hook_event({
-            "event": "SessionStart",
-            "session_id": "alias-1",
-            "cwd": "/tmp/test",
-        })
+        result = await process_hook_event(
+            {
+                "event": "SessionStart",
+                "session_id": "alias-1",
+                "cwd": "/tmp/test",
+            }
+        )
         assert result is not None
         assert result["status"] == "idle"
 
 
 async def test_check_stale_sessions_marks_stale():
     """Test _check_stale_sessions marks old sessions as stale."""
-    from server.hooks import _check_stale_sessions
     import server.hooks as hooks_mod
+    from server.hooks import _check_stale_sessions
 
     # Create a session with old activity
-    old_time = (datetime.now(timezone.utc) - timedelta(minutes=10)).isoformat()
+    old_time = (datetime.now(UTC) - timedelta(minutes=10)).isoformat()
     await db.create_session("stale-check-1")
     await db.update_session("stale-check-1", status="idle", last_activity_at=old_time)
 
     # Create a recent session
-    recent_time = datetime.now(timezone.utc).isoformat()
+    recent_time = datetime.now(UTC).isoformat()
     await db.create_session("stale-check-2")
     await db.update_session("stale-check-2", status="working", last_activity_at=recent_time)
 
@@ -400,12 +476,11 @@ async def test_check_stale_sessions_marks_stale():
         if call_count > 1:
             raise asyncio.CancelledError()
 
-    with patch("asyncio.sleep", side_effect=mock_sleep):
-        with patch.object(hooks_mod, "_on_session_update", new=None):
-            try:
-                await _check_stale_sessions()
-            except asyncio.CancelledError:
-                pass
+    with patch("asyncio.sleep", side_effect=mock_sleep), patch.object(hooks_mod, "_on_session_update", new=None):
+        try:
+            await _check_stale_sessions()
+        except asyncio.CancelledError:
+            pass
 
     s1 = await db.get_session("stale-check-1")
     assert s1["status"] == "stale"
@@ -418,11 +493,12 @@ async def test_check_stale_sessions_skips_completed():
     """_check_stale_sessions should skip completed/stale sessions."""
     from server.hooks import _check_stale_sessions
 
-    old_time = (datetime.now(timezone.utc) - timedelta(minutes=10)).isoformat()
+    old_time = (datetime.now(UTC) - timedelta(minutes=10)).isoformat()
     await db.create_session("stale-skip-1")
     await db.update_session("stale-skip-1", status="completed", last_activity_at=old_time)
 
     call_count = 0
+
     async def mock_sleep(seconds):
         nonlocal call_count
         call_count += 1
@@ -447,6 +523,7 @@ async def test_check_stale_sessions_no_last_activity():
     await db.update_session("stale-noact-1", status="idle")
 
     call_count = 0
+
     async def mock_sleep(seconds):
         nonlocal call_count
         call_count += 1
@@ -468,6 +545,7 @@ async def test_check_stale_sessions_handles_exception():
     from server.hooks import _check_stale_sessions
 
     call_count = 0
+
     async def mock_sleep(seconds):
         nonlocal call_count
         call_count += 1
@@ -487,11 +565,13 @@ async def test_project_path_with_git_branch_on_existing():
     """Test git branch is extracted when project path is set on existing session."""
     with patch("server.hooks._extract_git_branch", return_value="main"):
         await db.create_session("branch-update-1")
-        result = await process_hook_event({
-            "event_type": "PreToolUse",
-            "session_id": "branch-update-1",
-            "cwd": "/home/user/myproject",
-        })
+        result = await process_hook_event(
+            {
+                "event_type": "PreToolUse",
+                "session_id": "branch-update-1",
+                "cwd": "/home/user/myproject",
+            }
+        )
         assert result["git_branch"] == "main"
 
 
@@ -500,11 +580,12 @@ async def test_check_stale_sessions_timezone_naive():
     from server.hooks import _check_stale_sessions
 
     # Simulate a timezone-naive ISO timestamp without Z
-    old_naive = (datetime.now(timezone.utc) - timedelta(minutes=10)).strftime("%Y-%m-%dT%H:%M:%S")
+    old_naive = (datetime.now(UTC) - timedelta(minutes=10)).strftime("%Y-%m-%dT%H:%M:%S")
     await db.create_session("stale-naive-1")
     await db.update_session("stale-naive-1", status="idle", last_activity_at=old_naive)
 
     call_count = 0
+
     async def mock_sleep(seconds):
         nonlocal call_count
         call_count += 1
@@ -529,6 +610,7 @@ async def test_check_stale_sessions_invalid_timestamp():
     await db.update_session("stale-bad-ts", status="idle", last_activity_at="not-a-date")
 
     call_count = 0
+
     async def mock_sleep(seconds):
         nonlocal call_count
         call_count += 1
@@ -549,9 +631,8 @@ async def test_check_stale_sessions_invalid_timestamp():
 async def test_check_stale_notifies_on_update():
     """Test that stale checker notifies on session update."""
     from server.hooks import _check_stale_sessions, set_update_callback
-    import server.hooks as hooks_mod
 
-    old_time = (datetime.now(timezone.utc) - timedelta(minutes=10)).isoformat()
+    old_time = (datetime.now(UTC) - timedelta(minutes=10)).isoformat()
     await db.create_session("stale-notify-1")
     await db.update_session("stale-notify-1", status="idle", last_activity_at=old_time)
 
@@ -559,6 +640,7 @@ async def test_check_stale_notifies_on_update():
     set_update_callback(callback)
 
     call_count = 0
+
     async def mock_sleep(seconds):
         nonlocal call_count
         call_count += 1

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1,16 +1,16 @@
 """Tests for the main FastAPI app entry point."""
 
-import pytest
-from unittest.mock import AsyncMock, patch, MagicMock
+from unittest.mock import AsyncMock, patch
 
 from starlette.testclient import TestClient
 
 
 async def test_no_cache_middleware():
     """NoCacheStaticMiddleware adds no-cache headers to static files."""
-    from server.main import NoCacheStaticMiddleware
-    from fastapi import FastAPI, Request
+    from fastapi import FastAPI
     from starlette.responses import PlainTextResponse
+
+    from server.main import NoCacheStaticMiddleware
 
     app = FastAPI()
 
@@ -38,19 +38,21 @@ async def test_no_cache_middleware():
 
 async def test_lifespan():
     """Test that lifespan initializes and cleans up resources."""
-    from server.main import lifespan
     from fastapi import FastAPI
+
+    from server.main import lifespan
 
     app = FastAPI()
 
-    with patch("server.main.init_db", new_callable=AsyncMock) as mock_init, \
-         patch("server.main.close_db", new_callable=AsyncMock) as mock_close, \
-         patch("server.main.set_update_callback") as mock_set_cb, \
-         patch("server.main.start_stale_checker") as mock_start_stale, \
-         patch("server.main.stop_stale_checker") as mock_stop_stale, \
-         patch("server.main.start_watcher", new_callable=AsyncMock) as mock_start_watcher, \
-         patch("server.main.stop_watcher") as mock_stop_watcher:
-
+    with (
+        patch("server.main.init_db", new_callable=AsyncMock) as mock_init,
+        patch("server.main.close_db", new_callable=AsyncMock) as mock_close,
+        patch("server.main.set_update_callback") as mock_set_cb,
+        patch("server.main.start_stale_checker") as mock_start_stale,
+        patch("server.main.stop_stale_checker") as mock_stop_stale,
+        patch("server.main.start_watcher", new_callable=AsyncMock) as mock_start_watcher,
+        patch("server.main.stop_watcher") as mock_stop_watcher,
+    ):
         async with lifespan(app):
             mock_init.assert_called_once()
             mock_set_cb.assert_called_once()
@@ -65,4 +67,5 @@ async def test_lifespan():
 def test_app_exists():
     """Test that the app is properly configured."""
     from server.main import app
+
     assert app.title == "Claude Code Command Center"

--- a/tests/unit/test_pr_lookup.py
+++ b/tests/unit/test_pr_lookup.py
@@ -4,18 +4,15 @@ import os
 import tempfile
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import pytest
-
 from server.pr_lookup import (
+    _find_github_pr,
+    _find_gitlab_mr,
     _get_client,
     _get_github_token,
     _get_gitlab_token,
-    parse_git_remote,
     find_pr_url,
-    _find_github_pr,
-    _find_gitlab_mr,
+    parse_git_remote,
 )
-
 
 # --- Token resolution ---
 
@@ -27,34 +24,30 @@ def test_get_github_token_from_env():
 
 
 def test_get_github_token_gh_token_env():
-    with patch.dict(os.environ, {"GH_TOKEN": "ghp_alt"}, clear=False):
-        with patch("os.path.isfile", return_value=False):
-            token = _get_github_token()
-            # May get GITHUB_TOKEN if set in env; just verify it returns something or GH_TOKEN
-            assert token is not None or True  # non-fatal
+    with patch.dict(os.environ, {"GH_TOKEN": "ghp_alt"}, clear=False), patch("os.path.isfile", return_value=False):
+        token = _get_github_token()
+        # May get GITHUB_TOKEN if set in env; just verify it returns something or GH_TOKEN
+        assert token is not None  # non-fatal if env has no GH_TOKEN
 
 
 def test_get_github_token_no_token():
-    with patch.dict(os.environ, {}, clear=True):
-        with patch("os.path.isfile", return_value=False):
-            assert _get_github_token() is None
+    with patch.dict(os.environ, {}, clear=True), patch("os.path.isfile", return_value=False):
+        assert _get_github_token() is None
 
 
 def test_get_github_token_from_gh_config_no_yaml():
     """Test gh config parsing without yaml library (manual regex)."""
     config_content = "github.com:\n    oauth_token: ghp_fromconfig\n    user: testuser\n"
-    with patch.dict(os.environ, {}, clear=True):
-        with patch("os.path.isfile", return_value=True):
-            with patch("builtins.open", create=True) as mock_open:
-                # First call raises ImportError (no yaml), second call reads file
-                mock_open.return_value.__enter__ = lambda s: s
-                mock_open.return_value.__exit__ = MagicMock(return_value=False)
-                mock_open.return_value.read = MagicMock(return_value=config_content)
+    with patch.dict(os.environ, {}, clear=True), patch("os.path.isfile", return_value=True):
+        with patch("builtins.open", create=True) as mock_open:
+            # First call raises ImportError (no yaml), second call reads file
+            mock_open.return_value.__enter__ = lambda s: s
+            mock_open.return_value.__exit__ = MagicMock(return_value=False)
+            mock_open.return_value.read = MagicMock(return_value=config_content)
 
-                with patch.dict("sys.modules", {"yaml": None}):
-                    import importlib
-                    # Just test that the function doesn't crash
-                    token = _get_github_token()
+            with patch.dict("sys.modules", {"yaml": None}):
+                # Just test that the function doesn't crash
+                _get_github_token()
 
 
 def test_get_gitlab_token_from_env():
@@ -82,7 +75,9 @@ def test_parse_git_remote_ssh():
         git_dir = os.path.join(d, ".git")
         os.makedirs(git_dir)
         with open(os.path.join(git_dir, "config"), "w") as f:
-            f.write('[remote "origin"]\n\turl = git@github.com:owner/repo.git\n\tfetch = +refs/heads/*:refs/remotes/origin/*\n')
+            f.write(
+                '[remote "origin"]\n\turl = git@github.com:owner/repo.git\n\tfetch = +refs/heads/*:refs/remotes/origin/*\n'
+            )
 
         result = parse_git_remote(d)
         assert result is not None
@@ -153,7 +148,7 @@ def test_parse_git_remote_bad_config():
             f.write("this is not valid ini format \x00\x01\x02")
 
         # Should return None, not crash
-        result = parse_git_remote(d)
+        parse_git_remote(d)
         # configparser may or may not parse this; just ensure no exception
 
 
@@ -230,8 +225,7 @@ async def test_find_github_pr_with_token():
 
 
 async def test_find_gitlab_mr_success():
-    remote = {"host": "gitlab.com", "owner": "group", "repo": "repo",
-              "full_path": "group/repo", "platform": "gitlab"}
+    remote = {"host": "gitlab.com", "owner": "group", "repo": "repo", "full_path": "group/repo", "platform": "gitlab"}
     mock_response = MagicMock()
     mock_response.status_code = 200
     mock_response.json.return_value = [{"web_url": "https://gitlab.com/group/repo/-/merge_requests/10"}]
@@ -246,8 +240,7 @@ async def test_find_gitlab_mr_success():
 
 
 async def test_find_gitlab_mr_no_results():
-    remote = {"host": "gitlab.com", "owner": "group", "repo": "repo",
-              "full_path": "group/repo", "platform": "gitlab"}
+    remote = {"host": "gitlab.com", "owner": "group", "repo": "repo", "full_path": "group/repo", "platform": "gitlab"}
     mock_response = MagicMock()
     mock_response.status_code = 200
     mock_response.json.return_value = []
@@ -262,8 +255,7 @@ async def test_find_gitlab_mr_no_results():
 
 
 async def test_find_gitlab_mr_with_token():
-    remote = {"host": "gitlab.com", "owner": "group", "repo": "repo",
-              "full_path": "group/repo", "platform": "gitlab"}
+    remote = {"host": "gitlab.com", "owner": "group", "repo": "repo", "full_path": "group/repo", "platform": "gitlab"}
     mock_response = MagicMock()
     mock_response.status_code = 200
     mock_response.json.return_value = [{"web_url": "https://gitlab.com/group/repo/-/merge_requests/5"}]
@@ -281,8 +273,7 @@ async def test_find_gitlab_mr_with_token():
 
 
 async def test_find_gitlab_mr_api_error():
-    remote = {"host": "gitlab.com", "owner": "group", "repo": "repo",
-              "full_path": "group/repo", "platform": "gitlab"}
+    remote = {"host": "gitlab.com", "owner": "group", "repo": "repo", "full_path": "group/repo", "platform": "gitlab"}
     mock_response = MagicMock()
     mock_response.status_code = 500
 
@@ -332,35 +323,33 @@ async def test_find_pr_url_exception_returns_none():
 def test_get_github_token_from_gh_config_with_yaml():
     """Test gh config parsing with yaml library available."""
     mock_yaml = MagicMock()
-    mock_yaml.safe_load.return_value = {
-        "github.com": {"oauth_token": "ghp_yamltoken", "user": "testuser"}
-    }
+    mock_yaml.safe_load.return_value = {"github.com": {"oauth_token": "ghp_yamltoken", "user": "testuser"}}
 
-    with patch.dict(os.environ, {}, clear=True):
-        with patch("os.path.isfile", return_value=True):
-            with patch("builtins.open", MagicMock()):
-                import sys
-                with patch.dict(sys.modules, {"yaml": mock_yaml}):
-                    # Force reimport of the function to pick up yaml
-                    import importlib
-                    import server.pr_lookup as pr_mod
-                    # Directly test the function logic
-                    token = pr_mod._get_github_token()
+    with patch.dict(os.environ, {}, clear=True), patch("os.path.isfile", return_value=True):
+        with patch("builtins.open", MagicMock()):
+            import sys
+
+            with patch.dict(sys.modules, {"yaml": mock_yaml}):
+                # Force reimport of the function to pick up yaml
+                import server.pr_lookup as pr_mod
+
+                # Directly test the function logic
+                pr_mod._get_github_token()
 
 
 def test_get_github_token_gh_config_os_error():
     """Test gh config parsing when file read fails."""
-    with patch.dict(os.environ, {}, clear=True):
-        with patch("os.path.isfile", return_value=True):
-            with patch("builtins.open", side_effect=OSError("permission denied")):
-                # Should fall through to env vars and return None
-                token = _get_github_token()
-                assert token is None
+    with patch.dict(os.environ, {}, clear=True), patch("os.path.isfile", return_value=True):
+        with patch("builtins.open", side_effect=OSError("permission denied")):
+            # Should fall through to env vars and return None
+            token = _get_github_token()
+            assert token is None
 
 
 def test_get_client():
     """Test that _get_client returns a client."""
     import server.pr_lookup as pr_mod
+
     old = pr_mod._client
     pr_mod._client = None
     try:

--- a/tests/unit/test_terminal.py
+++ b/tests/unit/test_terminal.py
@@ -1,15 +1,16 @@
 """Tests for terminal/PTY management."""
 
 import subprocess
+from unittest.mock import MagicMock, patch
+
 import pytest
-from unittest.mock import patch, MagicMock
 
 from server.terminal import (
-    _tmux_session_name,
     _session_tmux_map,
+    _tmux_session_name,
     launch_session,
-    stop_session,
     list_tmux_sessions,
+    stop_session,
 )
 
 
@@ -91,6 +92,7 @@ async def test_list_tmux_sessions_with_data():
 async def test_attach_session_not_in_map():
     """Test attach_session when session not in map and tmux doesn't have it."""
     from server.terminal import attach_session
+
     with patch("server.terminal._run_tmux") as mock_tmux:
         mock_tmux.return_value = MagicMock(returncode=1, stdout="", stderr="no session")
         result = await attach_session("nonexistent-sess")
@@ -100,6 +102,7 @@ async def test_attach_session_not_in_map():
 async def test_attach_session_tmux_not_found():
     """Test attach_session when tmux binary is not found."""
     from server.terminal import attach_session
+
     with patch("server.terminal._run_tmux", side_effect=FileNotFoundError):
         result = await attach_session("no-tmux-sess")
         assert result is None
@@ -107,8 +110,9 @@ async def test_attach_session_tmux_not_found():
 
 async def test_detach_session():
     """Test detach_session closes fd and cleans up."""
-    from server.terminal import detach_session, _attached_fds
     import os
+
+    from server.terminal import _attached_fds, detach_session
 
     # Create a real fd pair so os.close works
     r, w = os.pipe()
@@ -123,7 +127,8 @@ async def test_detach_session():
 
 async def test_detach_session_already_closed():
     """Test detach_session when fd is already closed."""
-    from server.terminal import detach_session, _attached_fds
+    from server.terminal import _attached_fds, detach_session
+
     _attached_fds["detach-closed"] = [9999]
 
     # Should not raise even if fd is invalid
@@ -133,8 +138,9 @@ async def test_detach_session_already_closed():
 
 async def test_detach_session_fd_not_in_list():
     """Test detach_session when fd is not in the attached list."""
-    from server.terminal import detach_session, _attached_fds
     import os
+
+    from server.terminal import _attached_fds, detach_session
 
     r, w = os.pipe()
     _attached_fds["detach-missing"] = [r]
@@ -150,8 +156,10 @@ async def test_detach_session_fd_not_in_list():
 
 async def test_stop_session_with_tmux_name_in_map():
     """Test stop_session when session is tracked in the map."""
-    from server.terminal import stop_session as term_stop, _session_tmux_map, _attached_fds
     import os
+
+    from server.terminal import _attached_fds, _session_tmux_map
+    from server.terminal import stop_session as term_stop
 
     _session_tmux_map["stop-test"] = "cccc-stop-test"
     r, w = os.pipe()
@@ -168,7 +176,8 @@ async def test_stop_session_with_tmux_name_in_map():
 
 async def test_stop_session_tmux_timeout():
     """Test stop_session when tmux times out."""
-    from server.terminal import stop_session as term_stop, _session_tmux_map
+    from server.terminal import _session_tmux_map
+    from server.terminal import stop_session as term_stop
 
     with patch("server.terminal._run_tmux", side_effect=subprocess.TimeoutExpired("tmux", 10)):
         await term_stop("timeout-sess")  # Should not raise
@@ -186,17 +195,18 @@ async def test_list_tmux_sessions_timeout():
 def test_run_tmux():
     """Test _run_tmux helper."""
     from server.terminal import _run_tmux
+
     with patch("subprocess.run") as mock_run:
         mock_run.return_value = MagicMock(returncode=0)
-        result = _run_tmux("list-sessions", check=False)
+        _run_tmux("list-sessions", check=False)
         mock_run.assert_called_once()
         assert "tmux" in mock_run.call_args[0][0]
 
 
 async def test_attach_session_found_in_tmux():
     """Test attach when session is in tmux but not in map."""
-    from server.terminal import attach_session, _session_tmux_map
-    import asyncio
+
+    from server.terminal import _session_tmux_map, attach_session
 
     with patch("server.terminal._run_tmux") as mock_tmux:
         # has-session returns 0 (session exists)
@@ -206,6 +216,7 @@ async def test_attach_session_found_in_tmux():
                 mock_exec.return_value = MagicMock()
                 # Make it an awaitable
                 import asyncio as aio
+
                 future = aio.Future()
                 future.set_result(MagicMock())
                 mock_exec.return_value = future
@@ -218,7 +229,7 @@ async def test_attach_session_found_in_tmux():
 
 async def test_attach_session_subprocess_fails():
     """Test attach when subprocess creation fails."""
-    from server.terminal import attach_session, _session_tmux_map
+    from server.terminal import _session_tmux_map, attach_session
 
     with patch("server.terminal._run_tmux") as mock_tmux:
         mock_tmux.return_value = MagicMock(returncode=0)
@@ -235,7 +246,8 @@ async def test_attach_session_subprocess_fails():
 
 async def test_stop_session_closes_attached_fds():
     """Test that stop_session closes all attached FDs."""
-    from server.terminal import stop_session as term_stop, _session_tmux_map, _attached_fds
+    from server.terminal import _attached_fds, _session_tmux_map
+    from server.terminal import stop_session as term_stop
 
     _session_tmux_map["stop-fds"] = "cccc-stop-fds"
     _attached_fds["stop-fds"] = [1001, 1002]
@@ -251,7 +263,8 @@ async def test_stop_session_closes_attached_fds():
 
 async def test_stop_session_closes_fd_os_error():
     """Test stop_session handles OSError when closing fds."""
-    from server.terminal import stop_session as term_stop, _session_tmux_map, _attached_fds
+    from server.terminal import _attached_fds, _session_tmux_map
+    from server.terminal import stop_session as term_stop
 
     _session_tmux_map["stop-oserr"] = "cccc-stop-oserr"
     _attached_fds["stop-oserr"] = [9998, 9999]

--- a/tests/unit/test_watcher.py
+++ b/tests/unit/test_watcher.py
@@ -4,18 +4,19 @@ import asyncio
 import json
 import os
 import tempfile
-from unittest.mock import patch, AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+
 import server.db as db
 from server.watcher import (
+    _extract_activity_preview,
+    _extract_content,
+    _file_positions,
+    _generate_auto_title,
     _parse_jsonl_entry,
     _process_file_changes,
-    _file_positions,
-    _extract_content,
     _session_id_from_path,
-    _generate_auto_title,
-    _extract_activity_preview,
 )
 
 
@@ -28,11 +29,13 @@ async def setup_db():
 
 
 def test_parse_user_message():
-    line = json.dumps({
-        "type": "user",
-        "message": {"role": "user", "content": "Fix the auth bug"},
-        "timestamp": "2026-03-29T10:00:00Z",
-    })
+    line = json.dumps(
+        {
+            "type": "user",
+            "message": {"role": "user", "content": "Fix the auth bug"},
+            "timestamp": "2026-03-29T10:00:00Z",
+        }
+    )
     entry = _parse_jsonl_entry(line)
     assert entry is not None
     assert entry["role"] == "user"
@@ -41,14 +44,16 @@ def test_parse_user_message():
 
 
 def test_parse_assistant_text():
-    line = json.dumps({
-        "type": "assistant",
-        "message": {
-            "role": "assistant",
-            "content": [{"type": "text", "text": "I'll look into the auth module..."}],
-        },
-        "timestamp": "2026-03-29T10:00:05Z",
-    })
+    line = json.dumps(
+        {
+            "type": "assistant",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "I'll look into the auth module..."}],
+            },
+            "timestamp": "2026-03-29T10:00:05Z",
+        }
+    )
     entry = _parse_jsonl_entry(line)
     assert entry is not None
     assert entry["role"] == "assistant"
@@ -56,16 +61,18 @@ def test_parse_assistant_text():
 
 
 def test_parse_assistant_with_tool_use():
-    line = json.dumps({
-        "type": "assistant",
-        "message": {
-            "role": "assistant",
-            "content": [
-                {"type": "text", "text": "Let me read the file."},
-                {"type": "tool_use", "name": "Read", "input": {"file_path": "src/auth.ts"}},
-            ],
-        },
-    })
+    line = json.dumps(
+        {
+            "type": "assistant",
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {"type": "text", "text": "Let me read the file."},
+                    {"type": "tool_use", "name": "Read", "input": {"file_path": "src/auth.ts"}},
+                ],
+            },
+        }
+    )
     entry = _parse_jsonl_entry(line)
     assert entry is not None
     assert entry["role"] == "assistant"
@@ -74,12 +81,14 @@ def test_parse_assistant_with_tool_use():
 
 
 def test_parse_tool_result():
-    line = json.dumps({
-        "type": "tool_result",
-        "tool_use_id": "toolu_123",
-        "content": "file contents here...",
-        "timestamp": "2026-03-29T10:00:06Z",
-    })
+    line = json.dumps(
+        {
+            "type": "tool_result",
+            "tool_use_id": "toolu_123",
+            "content": "file contents here...",
+            "timestamp": "2026-03-29T10:00:06Z",
+        }
+    )
     entry = _parse_jsonl_entry(line)
     assert entry is not None
     assert entry["role"] == "tool_result"
@@ -98,15 +107,17 @@ def test_parse_empty_content():
 
 
 def test_parse_with_usage():
-    line = json.dumps({
-        "type": "assistant",
-        "message": {
-            "role": "assistant",
-            "content": "Hello",
-            "model": "claude-opus-4-6",
-            "usage": {"input_tokens": 100, "output_tokens": 50},
-        },
-    })
+    line = json.dumps(
+        {
+            "type": "assistant",
+            "message": {
+                "role": "assistant",
+                "content": "Hello",
+                "model": "claude-opus-4-6",
+                "usage": {"input_tokens": 100, "output_tokens": 50},
+            },
+        }
+    )
     entry = _parse_jsonl_entry(line)
     assert entry is not None
     assert entry["token_count"] == 150
@@ -141,19 +152,27 @@ def test_session_id_from_path():
 
 async def test_process_file_changes():
     """Test reading new lines from a JSONL file."""
-    with tempfile.NamedTemporaryFile(
-        mode="w", suffix=".jsonl", delete=False, dir=tempfile.gettempdir()
-    ) as f:
-        f.write(json.dumps({
-            "type": "user",
-            "message": {"role": "user", "content": "Hello world"},
-            "timestamp": "2026-03-29T10:00:00Z",
-        }) + "\n")
-        f.write(json.dumps({
-            "type": "assistant",
-            "message": {"role": "assistant", "content": "Hi there!"},
-            "timestamp": "2026-03-29T10:00:01Z",
-        }) + "\n")
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False, dir=tempfile.gettempdir()) as f:
+        f.write(
+            json.dumps(
+                {
+                    "type": "user",
+                    "message": {"role": "user", "content": "Hello world"},
+                    "timestamp": "2026-03-29T10:00:00Z",
+                }
+            )
+            + "\n"
+        )
+        f.write(
+            json.dumps(
+                {
+                    "type": "assistant",
+                    "message": {"role": "assistant", "content": "Hi there!"},
+                    "timestamp": "2026-03-29T10:00:01Z",
+                }
+            )
+            + "\n"
+        )
         tmp_path = f.name
 
     try:
@@ -170,13 +189,16 @@ async def test_process_file_changes():
 
 async def test_incremental_reading():
     """Test that only new lines are read on subsequent calls."""
-    with tempfile.NamedTemporaryFile(
-        mode="w", suffix=".jsonl", delete=False, dir=tempfile.gettempdir()
-    ) as f:
-        f.write(json.dumps({
-            "type": "user",
-            "message": {"role": "user", "content": "First message"},
-        }) + "\n")
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False, dir=tempfile.gettempdir()) as f:
+        f.write(
+            json.dumps(
+                {
+                    "type": "user",
+                    "message": {"role": "user", "content": "First message"},
+                }
+            )
+            + "\n"
+        )
         tmp_path = f.name
 
     try:
@@ -185,10 +207,15 @@ async def test_incremental_reading():
 
         # Add more lines
         with open(tmp_path, "a") as f:
-            f.write(json.dumps({
-                "type": "user",
-                "message": {"role": "user", "content": "Second message"},
-            }) + "\n")
+            f.write(
+                json.dumps(
+                    {
+                        "type": "user",
+                        "message": {"role": "user", "content": "Second message"},
+                    }
+                )
+                + "\n"
+            )
 
         await _process_file_changes(tmp_path)
         transcripts = await db.get_session_transcripts(session_id)
@@ -200,10 +227,12 @@ async def test_incremental_reading():
 
 
 def test_parse_result_type():
-    line = json.dumps({
-        "type": "result",
-        "result": "Task completed successfully",
-    })
+    line = json.dumps(
+        {
+            "type": "result",
+            "result": "Task completed successfully",
+        }
+    )
     entry = _parse_jsonl_entry(line)
     assert entry is not None
     assert entry["role"] == "assistant"
@@ -214,13 +243,15 @@ def test_large_tool_input_not_truncated():
     """Tool inputs are no longer truncated — the UI handles overflow."""
     large_content = "x" * 1000
     large_input = {"file_path": "/tmp/big.py", "content": large_content}
-    line = json.dumps({
-        "type": "assistant",
-        "message": {
-            "role": "assistant",
-            "content": [{"type": "tool_use", "name": "Write", "input": large_input}],
-        },
-    })
+    line = json.dumps(
+        {
+            "type": "assistant",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "tool_use", "name": "Write", "input": large_input}],
+            },
+        }
+    )
     entry = _parse_jsonl_entry(line)
     assert entry is not None
     assert "/tmp/big.py" in entry["content"]
@@ -232,23 +263,27 @@ def test_large_tool_input_not_truncated():
 
 def test_format_tool_result_string():
     from server.watcher import _format_tool_result
+
     assert _format_tool_result("hello") == "hello"
 
 
 def test_format_tool_result_stdout():
     from server.watcher import _format_tool_result
+
     result = _format_tool_result({"stdout": "output here", "stderr": ""})
     assert result == "output here"
 
 
 def test_format_tool_result_stderr():
     from server.watcher import _format_tool_result
+
     result = _format_tool_result({"stdout": "", "stderr": "error here"})
     assert result == "error here"
 
 
 def test_format_tool_result_file_path():
     from server.watcher import _format_tool_result
+
     result = _format_tool_result({"filePath": "/tmp/test.py", "type": "Write", "content": "code"})
     assert "/tmp/test.py" in result
     assert "Write" in result
@@ -257,18 +292,21 @@ def test_format_tool_result_file_path():
 
 def test_format_tool_result_file_path_no_content():
     from server.watcher import _format_tool_result
+
     result = _format_tool_result({"file_path": "/tmp/test.py"})
     assert result == "/tmp/test.py"
 
 
 def test_format_tool_result_dict_fallback():
     from server.watcher import _format_tool_result
+
     result = _format_tool_result({"key": "value"})
     assert "key" in result  # JSON serialized
 
 
 def test_format_tool_result_other_type():
     from server.watcher import _format_tool_result
+
     assert _format_tool_result(42) == "42"
 
 
@@ -277,11 +315,13 @@ def test_format_tool_result_other_type():
 
 def test_format_tool_summary_read():
     from server.watcher import _format_tool_summary
+
     assert _format_tool_summary("Read", {"file_path": "/tmp/a.py"}) == "/tmp/a.py"
 
 
 def test_format_tool_summary_write():
     from server.watcher import _format_tool_summary
+
     result = _format_tool_summary("Write", {"file_path": "/tmp/b.py", "content": "hello"})
     assert "/tmp/b.py" in result
     assert "hello" in result
@@ -289,12 +329,14 @@ def test_format_tool_summary_write():
 
 def test_format_tool_summary_write_no_content():
     from server.watcher import _format_tool_summary
+
     result = _format_tool_summary("Write", {"file_path": "/tmp/b.py"})
     assert result == "/tmp/b.py"
 
 
 def test_format_tool_summary_edit():
     from server.watcher import _format_tool_summary
+
     result = _format_tool_summary("Edit", {"file_path": "/tmp/c.py", "old_string": "old", "new_string": "new"})
     assert "---" in result
     assert "+++" in result
@@ -302,6 +344,7 @@ def test_format_tool_summary_edit():
 
 def test_format_tool_summary_bash():
     from server.watcher import _format_tool_summary
+
     result = _format_tool_summary("Bash", {"command": "ls -la", "description": "list files"})
     assert "$ ls -la" in result
     assert "# list files" in result
@@ -309,12 +352,14 @@ def test_format_tool_summary_bash():
 
 def test_format_tool_summary_bash_no_desc():
     from server.watcher import _format_tool_summary
+
     result = _format_tool_summary("Bash", {"command": "pwd"})
     assert result == "$ pwd"
 
 
 def test_format_tool_summary_grep():
     from server.watcher import _format_tool_summary
+
     result = _format_tool_summary("Grep", {"pattern": "TODO", "path": "src/"})
     assert "TODO" in result
     assert "src/" in result
@@ -322,54 +367,63 @@ def test_format_tool_summary_grep():
 
 def test_format_tool_summary_glob():
     from server.watcher import _format_tool_summary
+
     result = _format_tool_summary("Glob", {"pattern": "*.py", "path": "."})
     assert "*.py" in result
 
 
 def test_format_tool_summary_agent():
     from server.watcher import _format_tool_summary
+
     result = _format_tool_summary("Agent", {"prompt": "do something"})
     assert result == "do something"
 
 
 def test_format_tool_summary_agent_with_description():
     from server.watcher import _format_tool_summary
+
     result = _format_tool_summary("Agent", {"description": "agent desc"})
     assert result == "agent desc"
 
 
 def test_format_tool_summary_taskupdate():
     from server.watcher import _format_tool_summary
+
     result = _format_tool_summary("TaskUpdate", {"subject": "task subject"})
     assert result == "task subject"
 
 
 def test_format_tool_summary_enter_plan_mode():
     from server.watcher import _format_tool_summary
+
     result = _format_tool_summary("EnterPlanMode", {"description": "Planning implementation"})
     assert result == "Planning implementation"
 
 
 def test_format_tool_summary_enter_plan_mode_default():
     from server.watcher import _format_tool_summary
+
     result = _format_tool_summary("EnterPlanMode", {})
     assert result == "Entering plan mode"
 
 
 def test_format_tool_summary_exit_plan_mode():
     from server.watcher import _format_tool_summary
+
     result = _format_tool_summary("ExitPlanMode", {"description": "Plan complete"})
     assert result == "Plan complete"
 
 
 def test_format_tool_summary_exit_plan_mode_default():
     from server.watcher import _format_tool_summary
+
     result = _format_tool_summary("ExitPlanMode", {})
     assert result == "Exiting plan mode"
 
 
 def test_format_tool_summary_generic():
     from server.watcher import _format_tool_summary
+
     result = _format_tool_summary("CustomTool", {"arg1": "val1", "arg2": "val2"})
     assert "arg1: val1" in result
     assert "arg2: val2" in result
@@ -377,6 +431,7 @@ def test_format_tool_summary_generic():
 
 def test_format_tool_summary_non_dict():
     from server.watcher import _format_tool_summary
+
     assert _format_tool_summary("Tool", "just a string") == "just a string"
 
 
@@ -435,6 +490,7 @@ def test_extract_content_whitespace_string():
 
 def test_infer_context_max():
     from server.watcher import _infer_context_max
+
     assert _infer_context_max(None) == 200000
     assert _infer_context_max("claude-opus-4-6") == 1000000
     assert _infer_context_max("claude-sonnet-4-6") == 200000
@@ -447,6 +503,7 @@ def test_infer_context_max():
 
 async def test_extract_ticket_id_match():
     from server.watcher import _extract_ticket_id
+
     await db.set_setting("jira_project_keys", '["PROJ", "DEV"]')
     result = await _extract_ticket_id("feature/PROJ-123-fix-bug")
     assert result == "PROJ-123"
@@ -454,12 +511,14 @@ async def test_extract_ticket_id_match():
 
 async def test_extract_ticket_id_no_keys():
     from server.watcher import _extract_ticket_id
+
     result = await _extract_ticket_id("feature/PROJ-123")
     assert result is None
 
 
 async def test_extract_ticket_id_no_match():
     from server.watcher import _extract_ticket_id
+
     await db.set_setting("jira_project_keys", '["PROJ"]')
     result = await _extract_ticket_id("feature/no-ticket-here")
     assert result is None
@@ -467,6 +526,7 @@ async def test_extract_ticket_id_no_match():
 
 async def test_extract_ticket_id_bad_json():
     from server.watcher import _extract_ticket_id
+
     await db.set_setting("jira_project_keys", "not-json")
     result = await _extract_ticket_id("feature/PROJ-1")
     assert result is None
@@ -474,6 +534,7 @@ async def test_extract_ticket_id_bad_json():
 
 async def test_extract_ticket_id_empty_keys():
     from server.watcher import _extract_ticket_id
+
     await db.set_setting("jira_project_keys", "[]")
     result = await _extract_ticket_id("feature/PROJ-1")
     assert result is None
@@ -493,28 +554,34 @@ def test_parse_non_dict():
 
 
 def test_parse_user_meta_message():
-    line = json.dumps({
-        "type": "user",
-        "isMeta": True,
-        "message": {"role": "user", "content": "meta info"},
-    })
+    line = json.dumps(
+        {
+            "type": "user",
+            "isMeta": True,
+            "message": {"role": "user", "content": "meta info"},
+        }
+    )
     assert _parse_jsonl_entry(line) is None
 
 
 def test_parse_user_system_xml():
-    line = json.dumps({
-        "type": "user",
-        "message": {"role": "user", "content": "<command-start>test</command-start>"},
-    })
+    line = json.dumps(
+        {
+            "type": "user",
+            "message": {"role": "user", "content": "<command-start>test</command-start>"},
+        }
+    )
     assert _parse_jsonl_entry(line) is None
 
 
 def test_parse_user_with_tool_result():
-    line = json.dumps({
-        "type": "user",
-        "message": {"role": "user", "content": ""},
-        "toolUseResult": {"stdout": "output here", "stderr": ""},
-    })
+    line = json.dumps(
+        {
+            "type": "user",
+            "message": {"role": "user", "content": ""},
+            "toolUseResult": {"stdout": "output here", "stderr": ""},
+        }
+    )
     entry = _parse_jsonl_entry(line)
     assert entry is not None
     assert entry["role"] == "tool_result"
@@ -522,19 +589,21 @@ def test_parse_user_with_tool_result():
 
 
 def test_parse_assistant_with_cache_tokens():
-    line = json.dumps({
-        "type": "assistant",
-        "message": {
-            "role": "assistant",
-            "content": "Response text",
-            "usage": {
-                "input_tokens": 100,
-                "output_tokens": 50,
-                "cache_creation_input_tokens": 20,
-                "cache_read_input_tokens": 30,
+    line = json.dumps(
+        {
+            "type": "assistant",
+            "message": {
+                "role": "assistant",
+                "content": "Response text",
+                "usage": {
+                    "input_tokens": 100,
+                    "output_tokens": 50,
+                    "cache_creation_input_tokens": 20,
+                    "cache_read_input_tokens": 30,
+                },
             },
-        },
-    })
+        }
+    )
     entry = _parse_jsonl_entry(line)
     assert entry is not None
     assert entry["usage"]["cache_tokens"] == 50  # 20 + 30
@@ -542,25 +611,29 @@ def test_parse_assistant_with_cache_tokens():
 
 
 def test_parse_unknown_type_with_role_in_message():
-    line = json.dumps({
-        "type": "unknown",
-        "message": {"role": "system", "content": "some system message"},
-    })
+    line = json.dumps(
+        {
+            "type": "unknown",
+            "message": {"role": "system", "content": "some system message"},
+        }
+    )
     entry = _parse_jsonl_entry(line)
     assert entry is not None
     assert entry["role"] == "system"
 
 
 def test_parse_entry_with_metadata():
-    line = json.dumps({
-        "type": "assistant",
-        "message": {"role": "assistant", "content": "Hello"},
-        "gitBranch": "main",
-        "sessionId": "sess-1",
-        "cwd": "/tmp",
-        "slug": "my-session",
-        "effortLevel": "high",
-    })
+    line = json.dumps(
+        {
+            "type": "assistant",
+            "message": {"role": "assistant", "content": "Hello"},
+            "gitBranch": "main",
+            "sessionId": "sess-1",
+            "cwd": "/tmp",
+            "slug": "my-session",
+            "effortLevel": "high",
+        }
+    )
     entry = _parse_jsonl_entry(line)
     assert entry["git_branch"] == "main"
     assert entry["session_id"] == "sess-1"
@@ -571,10 +644,12 @@ def test_parse_entry_with_metadata():
 
 def test_parse_message_not_dict():
     """When message field is not a dict."""
-    line = json.dumps({
-        "type": "user",
-        "message": "just a string",
-    })
+    line = json.dumps(
+        {
+            "type": "user",
+            "message": "just a string",
+        }
+    )
     entry = _parse_jsonl_entry(line)
     # content comes from message.get("content") which fails -> falls back
     # The entry should be None since no content can be extracted
@@ -583,11 +658,13 @@ def test_parse_message_not_dict():
 
 def test_parse_user_fallback_to_top_level_content():
     """User message falls back to top-level content."""
-    line = json.dumps({
-        "type": "user",
-        "message": {"role": "user", "content": ""},
-        "content": "top-level content",
-    })
+    line = json.dumps(
+        {
+            "type": "user",
+            "message": {"role": "user", "content": ""},
+            "content": "top-level content",
+        }
+    )
     entry = _parse_jsonl_entry(line)
     assert entry is not None
     assert entry["content"] == "top-level content"
@@ -598,28 +675,40 @@ def test_parse_user_fallback_to_top_level_content():
 
 async def test_process_file_with_metadata_enrichment():
     """Test that session is enriched with model, branch, cwd from JSONL entries."""
-    with tempfile.NamedTemporaryFile(
-        mode="w", suffix=".jsonl", delete=False, dir=tempfile.gettempdir()
-    ) as f:
-        f.write(json.dumps({
-            "type": "user",
-            "message": {"role": "user", "content": "Fix the bug in authentication module"},
-            "timestamp": "2026-03-29T10:00:00Z",
-            "gitBranch": "feature/PROJ-42-fix-auth",
-            "cwd": "/home/user/myproject",
-        }) + "\n")
-        f.write(json.dumps({
-            "type": "assistant",
-            "message": {
-                "role": "assistant",
-                "content": "Looking into it",
-                "model": "claude-opus-4-6",
-                "usage": {"input_tokens": 500, "output_tokens": 100,
-                          "cache_creation_input_tokens": 0, "cache_read_input_tokens": 0},
-            },
-            "slug": "fix-auth",
-            "effortLevel": "high",
-        }) + "\n")
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False, dir=tempfile.gettempdir()) as f:
+        f.write(
+            json.dumps(
+                {
+                    "type": "user",
+                    "message": {"role": "user", "content": "Fix the bug in authentication module"},
+                    "timestamp": "2026-03-29T10:00:00Z",
+                    "gitBranch": "feature/PROJ-42-fix-auth",
+                    "cwd": "/home/user/myproject",
+                }
+            )
+            + "\n"
+        )
+        f.write(
+            json.dumps(
+                {
+                    "type": "assistant",
+                    "message": {
+                        "role": "assistant",
+                        "content": "Looking into it",
+                        "model": "claude-opus-4-6",
+                        "usage": {
+                            "input_tokens": 500,
+                            "output_tokens": 100,
+                            "cache_creation_input_tokens": 0,
+                            "cache_read_input_tokens": 0,
+                        },
+                    },
+                    "slug": "fix-auth",
+                    "effortLevel": "high",
+                }
+            )
+            + "\n"
+        )
         tmp_path = f.name
 
     try:
@@ -644,14 +733,17 @@ async def test_process_file_with_ticket_extraction():
     """Test that ticket ID is extracted from branch name."""
     await db.set_setting("jira_project_keys", '["PROJ"]')
 
-    with tempfile.NamedTemporaryFile(
-        mode="w", suffix=".jsonl", delete=False, dir=tempfile.gettempdir()
-    ) as f:
-        f.write(json.dumps({
-            "type": "user",
-            "message": {"role": "user", "content": "Working on the ticket"},
-            "gitBranch": "feature/PROJ-42-fix-auth",
-        }) + "\n")
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False, dir=tempfile.gettempdir()) as f:
+        f.write(
+            json.dumps(
+                {
+                    "type": "user",
+                    "message": {"role": "user", "content": "Working on the ticket"},
+                    "gitBranch": "feature/PROJ-42-fix-auth",
+                }
+            )
+            + "\n"
+        )
         tmp_path = f.name
 
     try:
@@ -665,22 +757,26 @@ async def test_process_file_with_ticket_extraction():
 
 async def test_process_file_pr_lookup():
     """Test that PR URL is looked up and stored."""
-    from unittest.mock import patch, AsyncMock
+    from unittest.mock import AsyncMock, patch
 
-    with tempfile.NamedTemporaryFile(
-        mode="w", suffix=".jsonl", delete=False, dir=tempfile.gettempdir()
-    ) as f:
-        f.write(json.dumps({
-            "type": "user",
-            "message": {"role": "user", "content": "Working on PR"},
-            "gitBranch": "feature/my-pr",
-            "cwd": "/home/user/repo",
-        }) + "\n")
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False, dir=tempfile.gettempdir()) as f:
+        f.write(
+            json.dumps(
+                {
+                    "type": "user",
+                    "message": {"role": "user", "content": "Working on PR"},
+                    "gitBranch": "feature/my-pr",
+                    "cwd": "/home/user/repo",
+                }
+            )
+            + "\n"
+        )
         tmp_path = f.name
 
     try:
-        with patch("server.watcher.find_pr_url", new_callable=AsyncMock,
-                    return_value="https://github.com/org/repo/pull/99"):
+        with patch(
+            "server.watcher.find_pr_url", new_callable=AsyncMock, return_value="https://github.com/org/repo/pull/99"
+        ):
             await _process_file_changes(tmp_path)
             session_id = os.path.splitext(os.path.basename(tmp_path))[0]
             session = await db.get_session(session_id)
@@ -691,22 +787,24 @@ async def test_process_file_pr_lookup():
 
 async def test_process_file_pr_lookup_failure():
     """PR lookup failure should not crash processing."""
-    from unittest.mock import patch, AsyncMock
+    from unittest.mock import AsyncMock, patch
 
-    with tempfile.NamedTemporaryFile(
-        mode="w", suffix=".jsonl", delete=False, dir=tempfile.gettempdir()
-    ) as f:
-        f.write(json.dumps({
-            "type": "user",
-            "message": {"role": "user", "content": "Working on something"},
-            "gitBranch": "main",
-            "cwd": "/tmp/proj",
-        }) + "\n")
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False, dir=tempfile.gettempdir()) as f:
+        f.write(
+            json.dumps(
+                {
+                    "type": "user",
+                    "message": {"role": "user", "content": "Working on something"},
+                    "gitBranch": "main",
+                    "cwd": "/tmp/proj",
+                }
+            )
+            + "\n"
+        )
         tmp_path = f.name
 
     try:
-        with patch("server.watcher.find_pr_url", new_callable=AsyncMock,
-                    side_effect=Exception("lookup failed")):
+        with patch("server.watcher.find_pr_url", new_callable=AsyncMock, side_effect=Exception("lookup failed")):
             await _process_file_changes(tmp_path)  # Should not raise
     finally:
         os.unlink(tmp_path)
@@ -814,15 +912,18 @@ def test_extract_activity_preview_uses_latest():
 
 async def test_process_file_auto_title_from_branch():
     """Auto-title should use git branch when available."""
-    with tempfile.NamedTemporaryFile(
-        mode="w", suffix=".jsonl", delete=False, dir=tempfile.gettempdir()
-    ) as f:
-        f.write(json.dumps({
-            "type": "user",
-            "message": {"role": "user", "content": "Fix the authentication bug in the login module"},
-            "timestamp": "2026-03-29T10:00:00Z",
-            "gitBranch": "feature/PROJ-42-fix-auth-bug",
-        }) + "\n")
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False, dir=tempfile.gettempdir()) as f:
+        f.write(
+            json.dumps(
+                {
+                    "type": "user",
+                    "message": {"role": "user", "content": "Fix the authentication bug in the login module"},
+                    "timestamp": "2026-03-29T10:00:00Z",
+                    "gitBranch": "feature/PROJ-42-fix-auth-bug",
+                }
+            )
+            + "\n"
+        )
         tmp_path = f.name
 
     try:
@@ -837,14 +938,17 @@ async def test_process_file_auto_title_from_branch():
 
 async def test_process_file_locked_skips_auto_title():
     """Locked sessions should not have their display_name overwritten."""
-    with tempfile.NamedTemporaryFile(
-        mode="w", suffix=".jsonl", delete=False, dir=tempfile.gettempdir()
-    ) as f:
-        f.write(json.dumps({
-            "type": "user",
-            "message": {"role": "user", "content": "Fix the authentication bug"},
-            "gitBranch": "feature/something-else",
-        }) + "\n")
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False, dir=tempfile.gettempdir()) as f:
+        f.write(
+            json.dumps(
+                {
+                    "type": "user",
+                    "message": {"role": "user", "content": "Fix the authentication bug"},
+                    "gitBranch": "feature/something-else",
+                }
+            )
+            + "\n"
+        )
         tmp_path = f.name
 
     try:
@@ -862,23 +966,39 @@ async def test_process_file_locked_skips_auto_title():
 
 async def test_process_file_preview_updated():
     """Preview should be set from tool call entries."""
-    with tempfile.NamedTemporaryFile(
-        mode="w", suffix=".jsonl", delete=False, dir=tempfile.gettempdir()
-    ) as f:
-        f.write(json.dumps({
-            "type": "user",
-            "message": {"role": "user", "content": "Fix the bug"},
-        }) + "\n")
-        f.write(json.dumps({
-            "type": "assistant",
-            "message": {
-                "role": "assistant",
-                "content": [
-                    {"type": "text", "text": "Let me edit the file."},
-                    {"type": "tool_use", "name": "Edit", "input": {"file_path": "/tmp/server/watcher.py", "old_string": "old", "new_string": "new"}},
-                ],
-            },
-        }) + "\n")
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False, dir=tempfile.gettempdir()) as f:
+        f.write(
+            json.dumps(
+                {
+                    "type": "user",
+                    "message": {"role": "user", "content": "Fix the bug"},
+                }
+            )
+            + "\n"
+        )
+        f.write(
+            json.dumps(
+                {
+                    "type": "assistant",
+                    "message": {
+                        "role": "assistant",
+                        "content": [
+                            {"type": "text", "text": "Let me edit the file."},
+                            {
+                                "type": "tool_use",
+                                "name": "Edit",
+                                "input": {
+                                    "file_path": "/tmp/server/watcher.py",
+                                    "old_string": "old",
+                                    "new_string": "new",
+                                },
+                            },
+                        ],
+                    },
+                }
+            )
+            + "\n"
+        )
         tmp_path = f.name
 
     try:
@@ -896,10 +1016,9 @@ async def test_process_file_preview_updated():
 
 
 async def test_schedule_process():
-    from server.watcher import _schedule_process, _debounce_tasks
-    import asyncio
+    from server.watcher import _debounce_tasks, _schedule_process
 
-    with patch("server.watcher._debounced_process", new_callable=AsyncMock) as mock_proc:
+    with patch("server.watcher._debounced_process", new_callable=AsyncMock):
         _schedule_process("/tmp/test.jsonl")
         assert "/tmp/test.jsonl" in _debounce_tasks
         # Cancel to clean up
@@ -912,8 +1031,7 @@ async def test_schedule_process():
 
 
 async def test_schedule_process_replaces_existing():
-    from server.watcher import _schedule_process, _debounce_tasks
-    import asyncio
+    from server.watcher import _debounce_tasks, _schedule_process
 
     with patch("server.watcher._debounced_process", new_callable=AsyncMock):
         _schedule_process("/tmp/replace.jsonl")
@@ -931,9 +1049,10 @@ async def test_schedule_process_replaces_existing():
 
 
 def test_stop_watcher():
-    from server.watcher import stop_watcher, _debounce_tasks
-    import server.watcher as watcher_mod
     from unittest.mock import MagicMock
+
+    import server.watcher as watcher_mod
+    from server.watcher import _debounce_tasks, stop_watcher
 
     mock_task = MagicMock()
     mock_task.done.return_value = False
@@ -954,7 +1073,6 @@ def test_stop_watcher():
 async def test_start_watcher_no_dir():
     """start_watcher should return early if projects dir doesn't exist."""
     from server.watcher import start_watcher
-    import server.watcher as watcher_mod
 
     with patch("os.path.isdir", return_value=False):
         await start_watcher()
@@ -963,13 +1081,16 @@ async def test_start_watcher_no_dir():
 
 async def test_process_file_skips_short_task_descriptions():
     """Short user messages (<= 5 chars) should not become task descriptions."""
-    with tempfile.NamedTemporaryFile(
-        mode="w", suffix=".jsonl", delete=False, dir=tempfile.gettempdir()
-    ) as f:
-        f.write(json.dumps({
-            "type": "user",
-            "message": {"role": "user", "content": "Hi"},
-        }) + "\n")
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False, dir=tempfile.gettempdir()) as f:
+        f.write(
+            json.dumps(
+                {
+                    "type": "user",
+                    "message": {"role": "user", "content": "Hi"},
+                }
+            )
+            + "\n"
+        )
         tmp_path = f.name
 
     try:
@@ -983,13 +1104,16 @@ async def test_process_file_skips_short_task_descriptions():
 
 async def test_process_file_empty_lines():
     """Test processing file with only empty lines after existing content."""
-    with tempfile.NamedTemporaryFile(
-        mode="w", suffix=".jsonl", delete=False, dir=tempfile.gettempdir()
-    ) as f:
-        f.write(json.dumps({
-            "type": "user",
-            "message": {"role": "user", "content": "Hello there from test"},
-        }) + "\n")
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False, dir=tempfile.gettempdir()) as f:
+        f.write(
+            json.dumps(
+                {
+                    "type": "user",
+                    "message": {"role": "user", "content": "Hello there from test"},
+                }
+            )
+            + "\n"
+        )
         tmp_path = f.name
 
     try:
@@ -1009,9 +1133,7 @@ async def test_process_file_empty_lines():
 
 async def test_process_file_task_description_not_overwritten():
     """Task description should not be overwritten if already set."""
-    with tempfile.NamedTemporaryFile(
-        mode="w", suffix=".jsonl", delete=False, dir=tempfile.gettempdir()
-    ) as f:
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False, dir=tempfile.gettempdir()) as f:
         tmp_path = f.name
         session_id = os.path.splitext(os.path.basename(tmp_path))[0]
 
@@ -1019,10 +1141,15 @@ async def test_process_file_task_description_not_overwritten():
     await db.create_session(session_id, task_description="Existing task")
 
     with open(tmp_path, "w") as f:
-        f.write(json.dumps({
-            "type": "user",
-            "message": {"role": "user", "content": "This is a new user message that is long enough"},
-        }) + "\n")
+        f.write(
+            json.dumps(
+                {
+                    "type": "user",
+                    "message": {"role": "user", "content": "This is a new user message that is long enough"},
+                }
+            )
+            + "\n"
+        )
 
     try:
         await _process_file_changes(tmp_path)
@@ -1036,11 +1163,10 @@ async def test_start_watcher_with_dir():
     """start_watcher should create a task when projects dir exists."""
     import server.watcher as watcher_mod
 
-    with patch("os.path.isdir", return_value=True):
-        with patch("asyncio.create_task") as mock_task:
-            mock_task.return_value = MagicMock()
-            # Mock watchfiles import
-            await watcher_mod.start_watcher()
+    with patch("os.path.isdir", return_value=True), patch("asyncio.create_task") as mock_task:
+        mock_task.return_value = MagicMock()
+        # Mock watchfiles import
+        await watcher_mod.start_watcher()
 
     # cleanup
     if watcher_mod._watcher_task and not isinstance(watcher_mod._watcher_task, MagicMock):
@@ -1050,23 +1176,26 @@ async def test_start_watcher_with_dir():
 
 async def test_process_file_with_context_tokens():
     """Test that context usage is calculated from latest usage snapshot."""
-    with tempfile.NamedTemporaryFile(
-        mode="w", suffix=".jsonl", delete=False, dir=tempfile.gettempdir()
-    ) as f:
-        f.write(json.dumps({
-            "type": "assistant",
-            "message": {
-                "role": "assistant",
-                "content": "Response",
-                "model": "claude-sonnet-4-6",
-                "usage": {
-                    "input_tokens": 50000,
-                    "output_tokens": 1000,
-                    "cache_creation_input_tokens": 10000,
-                    "cache_read_input_tokens": 5000,
-                },
-            },
-        }) + "\n")
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False, dir=tempfile.gettempdir()) as f:
+        f.write(
+            json.dumps(
+                {
+                    "type": "assistant",
+                    "message": {
+                        "role": "assistant",
+                        "content": "Response",
+                        "model": "claude-sonnet-4-6",
+                        "usage": {
+                            "input_tokens": 50000,
+                            "output_tokens": 1000,
+                            "cache_creation_input_tokens": 10000,
+                            "cache_read_input_tokens": 5000,
+                        },
+                    },
+                }
+            )
+            + "\n"
+        )
         tmp_path = f.name
 
     try:
@@ -1088,13 +1217,16 @@ async def test_process_file_with_context_tokens():
 
 async def test_process_file_reads_empty_after_position():
     """File with no new content after last read should return early."""
-    with tempfile.NamedTemporaryFile(
-        mode="w", suffix=".jsonl", delete=False, dir=tempfile.gettempdir()
-    ) as f:
-        f.write(json.dumps({
-            "type": "user",
-            "message": {"role": "user", "content": "Initial content here"},
-        }) + "\n")
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False, dir=tempfile.gettempdir()) as f:
+        f.write(
+            json.dumps(
+                {
+                    "type": "user",
+                    "message": {"role": "user", "content": "Initial content here"},
+                }
+            )
+            + "\n"
+        )
         tmp_path = f.name
 
     try:
@@ -1110,15 +1242,18 @@ async def test_process_file_reads_empty_after_position():
 
 async def test_process_file_with_unparseable_lines():
     """Unparseable lines should be skipped without error."""
-    with tempfile.NamedTemporaryFile(
-        mode="w", suffix=".jsonl", delete=False, dir=tempfile.gettempdir()
-    ) as f:
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False, dir=tempfile.gettempdir()) as f:
         f.write("not valid json\n")
         f.write(json.dumps({"type": "system", "data": "skip"}) + "\n")
-        f.write(json.dumps({
-            "type": "user",
-            "message": {"role": "user", "content": "Valid message here"},
-        }) + "\n")
+        f.write(
+            json.dumps(
+                {
+                    "type": "user",
+                    "message": {"role": "user", "content": "Valid message here"},
+                }
+            )
+            + "\n"
+        )
         tmp_path = f.name
 
     try:
@@ -1144,8 +1279,10 @@ async def test_debounced_process():
 
 async def test_start_watcher_import_error():
     """start_watcher handles missing watchfiles gracefully."""
-    import server.watcher as watcher_mod
     import builtins
+
+    import server.watcher as watcher_mod
+
     original_import = builtins.__import__
 
     def mock_import(name, *args, **kwargs):
@@ -1153,24 +1290,31 @@ async def test_start_watcher_import_error():
             raise ImportError("no watchfiles")
         return original_import(name, *args, **kwargs)
 
-    with patch("os.path.isdir", return_value=True):
-        with patch("builtins.__import__", side_effect=mock_import):
-            await watcher_mod.start_watcher()
+    with patch("os.path.isdir", return_value=True), patch("builtins.__import__", side_effect=mock_import):
+        await watcher_mod.start_watcher()
 
 
 async def test_process_file_skips_system_looking_content():
     """Messages starting with < or { or [ should not become task descriptions."""
-    with tempfile.NamedTemporaryFile(
-        mode="w", suffix=".jsonl", delete=False, dir=tempfile.gettempdir()
-    ) as f:
-        f.write(json.dumps({
-            "type": "user",
-            "message": {"role": "user", "content": "{json object here}"},
-        }) + "\n")
-        f.write(json.dumps({
-            "type": "user",
-            "message": {"role": "user", "content": "This is a real task for the session"},
-        }) + "\n")
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False, dir=tempfile.gettempdir()) as f:
+        f.write(
+            json.dumps(
+                {
+                    "type": "user",
+                    "message": {"role": "user", "content": "{json object here}"},
+                }
+            )
+            + "\n"
+        )
+        f.write(
+            json.dumps(
+                {
+                    "type": "user",
+                    "message": {"role": "user", "content": "This is a real task for the session"},
+                }
+            )
+            + "\n"
+        )
         tmp_path = f.name
 
     try:

--- a/tests/unit/test_ws.py
+++ b/tests/unit/test_ws.py
@@ -2,15 +2,15 @@
 
 import json
 import os
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
 from server.routes.ws import (
-    broadcast_session_update,
     _dashboard_clients,
     _read_pty_safe,
     _write_pty_safe,
+    broadcast_session_update,
 )
 
 
@@ -110,25 +110,26 @@ async def test_dashboard_ws_lifecycle():
     """Test dashboard WebSocket connect, initial state, ping/pong, disconnect."""
     from fastapi import FastAPI
     from starlette.testclient import TestClient
+
     import server.db as db
 
     await db.init_db(":memory:")
 
     app = FastAPI()
     from server.routes.ws import router
+
     app.include_router(router)
 
-    with TestClient(app) as client:
-        with client.websocket_connect("/ws/dashboard") as ws:
-            # Should receive initial_state
-            data = ws.receive_json()
-            assert data["type"] == "initial_state"
-            assert "sessions" in data
+    with TestClient(app) as client, client.websocket_connect("/ws/dashboard") as ws:
+        # Should receive initial_state
+        data = ws.receive_json()
+        assert data["type"] == "initial_state"
+        assert "sessions" in data
 
-            # Send ping, receive pong
-            ws.send_text("ping")
-            pong = ws.receive_json()
-            assert pong["type"] == "pong"
+        # Send ping, receive pong
+        ws.send_text("ping")
+        pong = ws.receive_json()
+        assert pong["type"] == "pong"
 
     await db.close_db()
 
@@ -137,8 +138,9 @@ async def test_terminal_ws_no_session():
     """Test terminal WebSocket when no terminal session exists."""
     from fastapi import FastAPI
     from starlette.testclient import TestClient
+
     import server.db as db
-    from server.routes.ws import router, _terminal_clients
+    from server.routes.ws import router
 
     await db.init_db(":memory:")
 
@@ -159,7 +161,7 @@ async def test_terminal_ws_with_session():
     """Test terminal WebSocket with a mock PTY."""
     from fastapi import FastAPI
     from starlette.testclient import TestClient
-    from starlette.websockets import WebSocketDisconnect
+
     import server.db as db
     from server.routes.ws import router
 
@@ -191,6 +193,7 @@ async def test_terminal_ws_send_text():
     """Test terminal WebSocket receiving text data and writing to PTY."""
     from fastapi import FastAPI
     from starlette.testclient import TestClient
+
     import server.db as db
     from server.routes.ws import router
 
@@ -230,6 +233,7 @@ async def test_terminal_ws_send_bytes():
     """Test terminal WebSocket receiving binary data."""
     from fastapi import FastAPI
     from starlette.testclient import TestClient
+
     import server.db as db
     from server.routes.ws import router
 
@@ -258,6 +262,7 @@ async def test_terminal_ws_exception_handling():
     """Test terminal WebSocket error path."""
     from fastapi import FastAPI
     from starlette.testclient import TestClient
+
     import server.db as db
     from server.routes.ws import router
 
@@ -279,18 +284,18 @@ async def test_dashboard_ws_exception_path():
     """Test dashboard WebSocket general exception handling."""
     from fastapi import FastAPI
     from starlette.testclient import TestClient
+
     import server.db as db
-    from server.routes.ws import router, _dashboard_clients
+    from server.routes.ws import _dashboard_clients, router
 
     await db.init_db(":memory:")
 
     app = FastAPI()
     app.include_router(router)
 
-    with TestClient(app) as client:
-        with client.websocket_connect("/ws/dashboard") as ws:
-            data = ws.receive_json()
-            assert data["type"] == "initial_state"
+    with TestClient(app) as client, client.websocket_connect("/ws/dashboard") as ws:
+        data = ws.receive_json()
+        assert data["type"] == "initial_state"
 
     # Client disconnected, should be removed
     assert len(_dashboard_clients) == 0

--- a/uv.lock
+++ b/uv.lock
@@ -3,6 +3,715 @@ revision = 3
 requires-python = ">=3.12"
 
 [[package]]
+name = "aiosqlite"
+version = "0.22.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/8a/64761f4005f17809769d23e518d915db74e6310474e733e3593cfc854ef1/aiosqlite-0.22.1.tar.gz", hash = "sha256:043e0bd78d32888c0a9ca90fc788b38796843360c855a7262a532813133a0650", size = 14821, upload-time = "2025-12-23T19:25:43.997Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/b7/e3bf5133d697a08128598c8d0abc5e16377b51465a33756de24fa7dee953/aiosqlite-0.22.1-py3-none-any.whl", hash = "sha256:21c002eb13823fad740196c5a2e9d8e62f6243bd9e7e4a1f87fb5e44ecb4fceb", size = 17405, upload-time = "2025-12-23T19:25:42.139Z" },
+]
+
+[[package]]
+name = "annotated-doc"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
+]
+
+[[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
+name = "anyio"
+version = "4.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.2.25"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/2d/7bf41579a8986e348fa033a31cdd0e4121114f6bce2457e8876010b092dd/certifi-2026.2.25.tar.gz", hash = "sha256:e887ab5cee78ea814d3472169153c2d12cd43b14bd03329a39a9c6e2e80bfba7", size = 155029, upload-time = "2026-02-25T02:54:17.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/3c/c17fb3ca2d9c3acff52e30b309f538586f9f5b9c9cf454f3845fc9af4881/certifi-2026.2.25-py3-none-any.whl", hash = "sha256:027692e4402ad994f1c42e52a4997a9763c646b73e4096e4d5d6db8af1d6f0fa", size = 153684, upload-time = "2026-02-25T02:54:15.766Z" },
+]
+
+[[package]]
 name = "claude-code-command-center"
 version = "0.1.0"
 source = { virtual = "." }
+dependencies = [
+    { name = "aiosqlite" },
+    { name = "fastapi" },
+    { name = "pyte" },
+    { name = "uuid6" },
+    { name = "uvicorn", extra = ["standard"] },
+    { name = "watchfiles" },
+    { name = "websockets" },
+]
+
+[package.optional-dependencies]
+dev = [
+    { name = "httpx" },
+    { name = "playwright" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "aiosqlite", specifier = ">=0.19.0" },
+    { name = "fastapi", specifier = ">=0.100.0" },
+    { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.24.0" },
+    { name = "playwright", marker = "extra == 'dev'", specifier = ">=1.40.0" },
+    { name = "pyte", specifier = ">=0.8.0" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21.0" },
+    { name = "uuid6", specifier = ">=2023.0.0" },
+    { name = "uvicorn", extras = ["standard"], specifier = ">=0.23.0" },
+    { name = "watchfiles", specifier = ">=0.20.0" },
+    { name = "websockets", specifier = ">=12.0" },
+]
+provides-extras = ["dev"]
+
+[[package]]
+name = "click"
+version = "8.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065, upload-time = "2025-11-15T20:45:42.706Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6", size = 108274, upload-time = "2025-11-15T20:45:41.139Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "fastapi"
+version = "0.135.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "pydantic" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c4/73/5903c4b13beae98618d64eb9870c3fac4f605523dd0312ca5c80dadbd5b9/fastapi-0.135.2.tar.gz", hash = "sha256:88a832095359755527b7f63bb4c6bc9edb8329a026189eed83d6c1afcf419d56", size = 395833, upload-time = "2026-03-23T14:12:41.697Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8f/ea/18f6d0457f9efb2fc6fa594857f92810cadb03024975726db6546b3d6fcf/fastapi-0.135.2-py3-none-any.whl", hash = "sha256:0af0447d541867e8db2a6a25c23a8c4bd80e2394ac5529bd87501bbb9e240ca5", size = 117407, upload-time = "2026-03-23T14:12:43.284Z" },
+]
+
+[[package]]
+name = "greenlet"
+version = "3.3.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/51/1664f6b78fc6ebbd98019a1fd730e83fa78f2db7058f72b1463d3612b8db/greenlet-3.3.2.tar.gz", hash = "sha256:2eaf067fc6d886931c7962e8c6bede15d2f01965560f3359b27c80bde2d151f2", size = 188267, upload-time = "2026-02-20T20:54:15.531Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ea/ab/1608e5a7578e62113506740b88066bf09888322a311cff602105e619bd87/greenlet-3.3.2-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:ac8d61d4343b799d1e526db579833d72f23759c71e07181c2d2944e429eb09cd", size = 280358, upload-time = "2026-02-20T20:17:43.971Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/23/0eae412a4ade4e6623ff7626e38998cb9b11e9ff1ebacaa021e4e108ec15/greenlet-3.3.2-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3ceec72030dae6ac0c8ed7591b96b70410a8be370b6a477b1dbc072856ad02bd", size = 601217, upload-time = "2026-02-20T20:47:31.462Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/16/5b1678a9c07098ecb9ab2dd159fafaf12e963293e61ee8d10ecb55273e5e/greenlet-3.3.2-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a2a5be83a45ce6188c045bcc44b0ee037d6a518978de9a5d97438548b953a1ac", size = 611792, upload-time = "2026-02-20T20:55:58.423Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/c5/cc09412a29e43406eba18d61c70baa936e299bc27e074e2be3806ed29098/greenlet-3.3.2-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ae9e21c84035c490506c17002f5c8ab25f980205c3e61ddb3a2a2a2e6c411fcb", size = 626250, upload-time = "2026-02-20T21:02:46.596Z" },
+    { url = "https://files.pythonhosted.org/packages/50/1f/5155f55bd71cabd03765a4aac9ac446be129895271f73872c36ebd4b04b6/greenlet-3.3.2-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:43e99d1749147ac21dde49b99c9abffcbc1e2d55c67501465ef0930d6e78e070", size = 613875, upload-time = "2026-02-20T20:21:01.102Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/dd/845f249c3fcd69e32df80cdab059b4be8b766ef5830a3d0aa9d6cad55beb/greenlet-3.3.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:4c956a19350e2c37f2c48b336a3afb4bff120b36076d9d7fb68cb44e05d95b79", size = 1571467, upload-time = "2026-02-20T20:49:33.495Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/50/2649fe21fcc2b56659a452868e695634722a6655ba245d9f77f5656010bf/greenlet-3.3.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6c6f8ba97d17a1e7d664151284cb3315fc5f8353e75221ed4324f84eb162b395", size = 1640001, upload-time = "2026-02-20T20:21:09.154Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/40/cc802e067d02af8b60b6771cea7d57e21ef5e6659912814babb42b864713/greenlet-3.3.2-cp312-cp312-win_amd64.whl", hash = "sha256:34308836d8370bddadb41f5a7ce96879b72e2fdfb4e87729330c6ab52376409f", size = 231081, upload-time = "2026-02-20T20:17:28.121Z" },
+    { url = "https://files.pythonhosted.org/packages/58/2e/fe7f36ff1982d6b10a60d5e0740c759259a7d6d2e1dc41da6d96de32fff6/greenlet-3.3.2-cp312-cp312-win_arm64.whl", hash = "sha256:d3a62fa76a32b462a97198e4c9e99afb9ab375115e74e9a83ce180e7a496f643", size = 230331, upload-time = "2026-02-20T20:17:23.34Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/48/f8b875fa7dea7dd9b33245e37f065af59df6a25af2f9561efa8d822fde51/greenlet-3.3.2-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:aa6ac98bdfd716a749b84d4034486863fd81c3abde9aa3cf8eff9127981a4ae4", size = 279120, upload-time = "2026-02-20T20:19:01.9Z" },
+    { url = "https://files.pythonhosted.org/packages/49/8d/9771d03e7a8b1ee456511961e1b97a6d77ae1dea4a34a5b98eee706689d3/greenlet-3.3.2-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ab0c7e7901a00bc0a7284907273dc165b32e0d109a6713babd04471327ff7986", size = 603238, upload-time = "2026-02-20T20:47:32.873Z" },
+    { url = "https://files.pythonhosted.org/packages/59/0e/4223c2bbb63cd5c97f28ffb2a8aee71bdfb30b323c35d409450f51b91e3e/greenlet-3.3.2-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d248d8c23c67d2291ffd47af766e2a3aa9fa1c6703155c099feb11f526c63a92", size = 614219, upload-time = "2026-02-20T20:55:59.817Z" },
+    { url = "https://files.pythonhosted.org/packages/94/2b/4d012a69759ac9d77210b8bfb128bc621125f5b20fc398bce3940d036b1c/greenlet-3.3.2-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ccd21bb86944ca9be6d967cf7691e658e43417782bce90b5d2faeda0ff78a7dd", size = 628268, upload-time = "2026-02-20T21:02:48.024Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/34/259b28ea7a2a0c904b11cd36c79b8cef8019b26ee5dbe24e73b469dea347/greenlet-3.3.2-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b6997d360a4e6a4e936c0f9625b1c20416b8a0ea18a8e19cabbefc712e7397ab", size = 616774, upload-time = "2026-02-20T20:21:02.454Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/03/996c2d1689d486a6e199cb0f1cf9e4aa940c500e01bdf201299d7d61fa69/greenlet-3.3.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:64970c33a50551c7c50491671265d8954046cb6e8e2999aacdd60e439b70418a", size = 1571277, upload-time = "2026-02-20T20:49:34.795Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/c4/2570fc07f34a39f2caf0bf9f24b0a1a0a47bc2e8e465b2c2424821389dfc/greenlet-3.3.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1a9172f5bf6bd88e6ba5a84e0a68afeac9dc7b6b412b245dd64f52d83c81e55b", size = 1640455, upload-time = "2026-02-20T20:21:10.261Z" },
+    { url = "https://files.pythonhosted.org/packages/91/39/5ef5aa23bc545aa0d31e1b9b55822b32c8da93ba657295840b6b34124009/greenlet-3.3.2-cp313-cp313-win_amd64.whl", hash = "sha256:a7945dd0eab63ded0a48e4dcade82939783c172290a7903ebde9e184333ca124", size = 230961, upload-time = "2026-02-20T20:16:58.461Z" },
+    { url = "https://files.pythonhosted.org/packages/62/6b/a89f8456dcb06becff288f563618e9f20deed8dd29beea14f9a168aef64b/greenlet-3.3.2-cp313-cp313-win_arm64.whl", hash = "sha256:394ead29063ee3515b4e775216cb756b2e3b4a7e55ae8fd884f17fa579e6b327", size = 230221, upload-time = "2026-02-20T20:17:37.152Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/ae/8bffcbd373b57a5992cd077cbe8858fff39110480a9d50697091faea6f39/greenlet-3.3.2-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:8d1658d7291f9859beed69a776c10822a0a799bc4bfe1bd4272bb60e62507dab", size = 279650, upload-time = "2026-02-20T20:18:00.783Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/c0/45f93f348fa49abf32ac8439938726c480bd96b2a3c6f4d949ec0124b69f/greenlet-3.3.2-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:18cb1b7337bca281915b3c5d5ae19f4e76d35e1df80f4ad3c1a7be91fadf1082", size = 650295, upload-time = "2026-02-20T20:47:34.036Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/de/dd7589b3f2b8372069ab3e4763ea5329940fc7ad9dcd3e272a37516d7c9b/greenlet-3.3.2-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c2e47408e8ce1c6f1ceea0dffcdf6ebb85cc09e55c7af407c99f1112016e45e9", size = 662163, upload-time = "2026-02-20T20:56:01.295Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/ac/85804f74f1ccea31ba518dcc8ee6f14c79f73fe36fa1beba38930806df09/greenlet-3.3.2-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:e3cb43ce200f59483eb82949bf1835a99cf43d7571e900d7c8d5c62cdf25d2f9", size = 675371, upload-time = "2026-02-20T21:02:49.664Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/d8/09bfa816572a4d83bccd6750df1926f79158b1c36c5f73786e26dbe4ee38/greenlet-3.3.2-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:63d10328839d1973e5ba35e98cccbca71b232b14051fd957b6f8b6e8e80d0506", size = 664160, upload-time = "2026-02-20T20:21:04.015Z" },
+    { url = "https://files.pythonhosted.org/packages/48/cf/56832f0c8255d27f6c35d41b5ec91168d74ec721d85f01a12131eec6b93c/greenlet-3.3.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:8e4ab3cfb02993c8cc248ea73d7dae6cec0253e9afa311c9b37e603ca9fad2ce", size = 1619181, upload-time = "2026-02-20T20:49:36.052Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/23/b90b60a4aabb4cec0796e55f25ffbfb579a907c3898cd2905c8918acaa16/greenlet-3.3.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:94ad81f0fd3c0c0681a018a976e5c2bd2ca2d9d94895f23e7bb1af4e8af4e2d5", size = 1687713, upload-time = "2026-02-20T20:21:11.684Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/ca/2101ca3d9223a1dc125140dbc063644dca76df6ff356531eb27bc267b446/greenlet-3.3.2-cp314-cp314-win_amd64.whl", hash = "sha256:8c4dd0f3997cf2512f7601563cc90dfb8957c0cff1e3a1b23991d4ea1776c492", size = 232034, upload-time = "2026-02-20T20:20:08.186Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/4a/ecf894e962a59dea60f04877eea0fd5724618da89f1867b28ee8b91e811f/greenlet-3.3.2-cp314-cp314-win_arm64.whl", hash = "sha256:cd6f9e2bbd46321ba3bbb4c8a15794d32960e3b0ae2cc4d49a1a53d314805d71", size = 231437, upload-time = "2026-02-20T20:18:59.722Z" },
+    { url = "https://files.pythonhosted.org/packages/98/6d/8f2ef704e614bcf58ed43cfb8d87afa1c285e98194ab2cfad351bf04f81e/greenlet-3.3.2-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:e26e72bec7ab387ac80caa7496e0f908ff954f31065b0ffc1f8ecb1338b11b54", size = 286617, upload-time = "2026-02-20T20:19:29.856Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/0d/93894161d307c6ea237a43988f27eba0947b360b99ac5239ad3fe09f0b47/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8b466dff7a4ffda6ca975979bab80bdadde979e29fc947ac3be4451428d8b0e4", size = 655189, upload-time = "2026-02-20T20:47:35.742Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/2c/d2d506ebd8abcb57386ec4f7ba20f4030cbe56eae541bc6fd6ef399c0b41/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b8bddc5b73c9720bea487b3bffdb1840fe4e3656fba3bd40aa1489e9f37877ff", size = 658225, upload-time = "2026-02-20T20:56:02.527Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/67/8197b7e7e602150938049d8e7f30de1660cfb87e4c8ee349b42b67bdb2e1/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:59b3e2c40f6706b05a9cd299c836c6aa2378cabe25d021acd80f13abf81181cf", size = 666581, upload-time = "2026-02-20T21:02:51.526Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/30/3a09155fbf728673a1dea713572d2d31159f824a37c22da82127056c44e4/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b26b0f4428b871a751968285a1ac9648944cea09807177ac639b030bddebcea4", size = 657907, upload-time = "2026-02-20T20:21:05.259Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/fd/d05a4b7acd0154ed758797f0a43b4c0962a843bedfe980115e842c5b2d08/greenlet-3.3.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:1fb39a11ee2e4d94be9a76671482be9398560955c9e568550de0224e41104727", size = 1618857, upload-time = "2026-02-20T20:49:37.309Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/e1/50ee92a5db521de8f35075b5eff060dd43d39ebd46c2181a2042f7070385/greenlet-3.3.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:20154044d9085151bc309e7689d6f7ba10027f8f5a8c0676ad398b951913d89e", size = 1680010, upload-time = "2026-02-20T20:21:13.427Z" },
+    { url = "https://files.pythonhosted.org/packages/29/4b/45d90626aef8e65336bed690106d1382f7a43665e2249017e9527df8823b/greenlet-3.3.2-cp314-cp314t-win_amd64.whl", hash = "sha256:c04c5e06ec3e022cbfe2cd4a846e1d4e50087444f875ff6d2c2ad8445495cf1a", size = 237086, upload-time = "2026-02-20T20:20:45.786Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httptools"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/46/120a669232c7bdedb9d52d4aeae7e6c7dfe151e99dc70802e2fc7a5e1993/httptools-0.7.1.tar.gz", hash = "sha256:abd72556974f8e7c74a259655924a717a2365b236c882c3f6f8a45fe94703ac9", size = 258961, upload-time = "2025-10-10T03:55:08.559Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/53/7f/403e5d787dc4942316e515e949b0c8a013d84078a915910e9f391ba9b3ed/httptools-0.7.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:38e0c83a2ea9746ebbd643bdfb521b9aa4a91703e2cd705c20443405d2fd16a5", size = 206280, upload-time = "2025-10-10T03:54:39.274Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/0d/7f3fd28e2ce311ccc998c388dd1c53b18120fda3b70ebb022b135dc9839b/httptools-0.7.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f25bbaf1235e27704f1a7b86cd3304eabc04f569c828101d94a0e605ef7205a5", size = 110004, upload-time = "2025-10-10T03:54:40.403Z" },
+    { url = "https://files.pythonhosted.org/packages/84/a6/b3965e1e146ef5762870bbe76117876ceba51a201e18cc31f5703e454596/httptools-0.7.1-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2c15f37ef679ab9ecc06bfc4e6e8628c32a8e4b305459de7cf6785acd57e4d03", size = 517655, upload-time = "2025-10-10T03:54:41.347Z" },
+    { url = "https://files.pythonhosted.org/packages/11/7d/71fee6f1844e6fa378f2eddde6c3e41ce3a1fb4b2d81118dd544e3441ec0/httptools-0.7.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7fe6e96090df46b36ccfaf746f03034e5ab723162bc51b0a4cf58305324036f2", size = 511440, upload-time = "2025-10-10T03:54:42.452Z" },
+    { url = "https://files.pythonhosted.org/packages/22/a5/079d216712a4f3ffa24af4a0381b108aa9c45b7a5cc6eb141f81726b1823/httptools-0.7.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f72fdbae2dbc6e68b8239defb48e6a5937b12218e6ffc2c7846cc37befa84362", size = 495186, upload-time = "2025-10-10T03:54:43.937Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/9e/025ad7b65278745dee3bd0ebf9314934c4592560878308a6121f7f812084/httptools-0.7.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e99c7b90a29fd82fea9ef57943d501a16f3404d7b9ee81799d41639bdaae412c", size = 499192, upload-time = "2025-10-10T03:54:45.003Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/de/40a8f202b987d43afc4d54689600ff03ce65680ede2f31df348d7f368b8f/httptools-0.7.1-cp312-cp312-win_amd64.whl", hash = "sha256:3e14f530fefa7499334a79b0cf7e7cd2992870eb893526fb097d51b4f2d0f321", size = 86694, upload-time = "2025-10-10T03:54:45.923Z" },
+    { url = "https://files.pythonhosted.org/packages/09/8f/c77b1fcbfd262d422f12da02feb0d218fa228d52485b77b953832105bb90/httptools-0.7.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:6babce6cfa2a99545c60bfef8bee0cc0545413cb0018f617c8059a30ad985de3", size = 202889, upload-time = "2025-10-10T03:54:47.089Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/1a/22887f53602feaa066354867bc49a68fc295c2293433177ee90870a7d517/httptools-0.7.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:601b7628de7504077dd3dcb3791c6b8694bbd967148a6d1f01806509254fb1ca", size = 108180, upload-time = "2025-10-10T03:54:48.052Z" },
+    { url = "https://files.pythonhosted.org/packages/32/6a/6aaa91937f0010d288d3d124ca2946d48d60c3a5ee7ca62afe870e3ea011/httptools-0.7.1-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:04c6c0e6c5fb0739c5b8a9eb046d298650a0ff38cf42537fc372b28dc7e4472c", size = 478596, upload-time = "2025-10-10T03:54:48.919Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/70/023d7ce117993107be88d2cbca566a7c1323ccbaf0af7eabf2064fe356f6/httptools-0.7.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:69d4f9705c405ae3ee83d6a12283dc9feba8cc6aaec671b412917e644ab4fa66", size = 473268, upload-time = "2025-10-10T03:54:49.993Z" },
+    { url = "https://files.pythonhosted.org/packages/32/4d/9dd616c38da088e3f436e9a616e1d0cc66544b8cdac405cc4e81c8679fc7/httptools-0.7.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:44c8f4347d4b31269c8a9205d8a5ee2df5322b09bbbd30f8f862185bb6b05346", size = 455517, upload-time = "2025-10-10T03:54:51.066Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/3a/a6c595c310b7df958e739aae88724e24f9246a514d909547778d776799be/httptools-0.7.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:465275d76db4d554918aba40bf1cbebe324670f3dfc979eaffaa5d108e2ed650", size = 458337, upload-time = "2025-10-10T03:54:52.196Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/82/88e8d6d2c51edc1cc391b6e044c6c435b6aebe97b1abc33db1b0b24cd582/httptools-0.7.1-cp313-cp313-win_amd64.whl", hash = "sha256:322d00c2068d125bd570f7bf78b2d367dad02b919d8581d7476d8b75b294e3e6", size = 85743, upload-time = "2025-10-10T03:54:53.448Z" },
+    { url = "https://files.pythonhosted.org/packages/34/50/9d095fcbb6de2d523e027a2f304d4551855c2f46e0b82befd718b8b20056/httptools-0.7.1-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:c08fe65728b8d70b6923ce31e3956f859d5e1e8548e6f22ec520a962c6757270", size = 203619, upload-time = "2025-10-10T03:54:54.321Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f0/89720dc5139ae54b03f861b5e2c55a37dba9a5da7d51e1e824a1f343627f/httptools-0.7.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:7aea2e3c3953521c3c51106ee11487a910d45586e351202474d45472db7d72d3", size = 108714, upload-time = "2025-10-10T03:54:55.163Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/cb/eea88506f191fb552c11787c23f9a405f4c7b0c5799bf73f2249cd4f5228/httptools-0.7.1-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0e68b8582f4ea9166be62926077a3334064d422cf08ab87d8b74664f8e9058e1", size = 472909, upload-time = "2025-10-10T03:54:56.056Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/4a/a548bdfae6369c0d078bab5769f7b66f17f1bfaa6fa28f81d6be6959066b/httptools-0.7.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:df091cf961a3be783d6aebae963cc9b71e00d57fa6f149025075217bc6a55a7b", size = 470831, upload-time = "2025-10-10T03:54:57.219Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/31/14df99e1c43bd132eec921c2e7e11cda7852f65619bc0fc5bdc2d0cb126c/httptools-0.7.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:f084813239e1eb403ddacd06a30de3d3e09a9b76e7894dcda2b22f8a726e9c60", size = 452631, upload-time = "2025-10-10T03:54:58.219Z" },
+    { url = "https://files.pythonhosted.org/packages/22/d2/b7e131f7be8d854d48cb6d048113c30f9a46dca0c9a8b08fcb3fcd588cdc/httptools-0.7.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7347714368fb2b335e9063bc2b96f2f87a9ceffcd9758ac295f8bbcd3ffbc0ca", size = 452910, upload-time = "2025-10-10T03:54:59.366Z" },
+    { url = "https://files.pythonhosted.org/packages/53/cf/878f3b91e4e6e011eff6d1fa9ca39f7eb17d19c9d7971b04873734112f30/httptools-0.7.1-cp314-cp314-win_amd64.whl", hash = "sha256:cfabda2a5bb85aa2a904ce06d974a3f30fb36cc63d7feaddec05d2050acede96", size = 88205, upload-time = "2025-10-10T03:55:00.389Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.11"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
+]
+
+[[package]]
+name = "playwright"
+version = "1.58.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "greenlet" },
+    { name = "pyee" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f8/c9/9c6061d5703267f1baae6a4647bfd1862e386fbfdb97d889f6f6ae9e3f64/playwright-1.58.0-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:96e3204aac292ee639edbfdef6298b4be2ea0a55a16b7068df91adac077cc606", size = 42251098, upload-time = "2026-01-30T15:09:24.028Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/40/59d34a756e02f8c670f0fee987d46f7ee53d05447d43cd114ca015cb168c/playwright-1.58.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:70c763694739d28df71ed578b9c8202bb83e8fe8fb9268c04dd13afe36301f71", size = 41039625, upload-time = "2026-01-30T15:09:27.558Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/ee/3ce6209c9c74a650aac9028c621f357a34ea5cd4d950700f8e2c4b7fe2c4/playwright-1.58.0-py3-none-macosx_11_0_universal2.whl", hash = "sha256:185e0132578733d02802dfddfbbc35f42be23a45ff49ccae5081f25952238117", size = 42251098, upload-time = "2026-01-30T15:09:30.461Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/af/009958cbf23fac551a940d34e3206e6c7eed2b8c940d0c3afd1feb0b0589/playwright-1.58.0-py3-none-manylinux1_x86_64.whl", hash = "sha256:c95568ba1eda83812598c1dc9be60b4406dffd60b149bc1536180ad108723d6b", size = 46235268, upload-time = "2026-01-30T15:09:33.787Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/a6/0e66ad04b6d3440dae73efb39540c5685c5fc95b17c8b29340b62abbd952/playwright-1.58.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8f9999948f1ab541d98812de25e3a8c410776aa516d948807140aff797b4bffa", size = 45964214, upload-time = "2026-01-30T15:09:36.751Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/4b/236e60ab9f6d62ed0fd32150d61f1f494cefbf02304c0061e78ed80c1c32/playwright-1.58.0-py3-none-win32.whl", hash = "sha256:1e03be090e75a0fabbdaeab65ce17c308c425d879fa48bb1d7986f96bfad0b99", size = 36815998, upload-time = "2026-01-30T15:09:39.627Z" },
+    { url = "https://files.pythonhosted.org/packages/41/f8/5ec599c5e59d2f2f336a05b4f318e733077cd5044f24adb6f86900c3e6a7/playwright-1.58.0-py3-none-win_amd64.whl", hash = "sha256:a2bf639d0ce33b3ba38de777e08697b0d8f3dc07ab6802e4ac53fb65e3907af8", size = 36816005, upload-time = "2026-01-30T15:09:42.449Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/c4/cc0229fea55c87d6c9c67fe44a21e2cd28d1d558a5478ed4d617e9fb0c93/playwright-1.58.0-py3-none-win_arm64.whl", hash = "sha256:32ffe5c303901a13a0ecab91d1c3f74baf73b84f4bedbb6b935f5bc11cc98e1b", size = 33085919, upload-time = "2026-01-30T15:09:45.71Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pydantic"
+version = "2.12.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/69/44/36f1a6e523abc58ae5f928898e4aca2e0ea509b5aa6f6f392a5d882be928/pydantic-2.12.5.tar.gz", hash = "sha256:4d351024c75c0f085a9febbb665ce8c0c6ec5d30e903bdb6394b7ede26aebb49", size = 821591, upload-time = "2025-11-26T15:11:46.471Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/87/b70ad306ebb6f9b585f114d0ac2137d792b48be34d732d60e597c2f8465a/pydantic-2.12.5-py3-none-any.whl", hash = "sha256:e561593fccf61e8a20fc46dfc2dfe075b8be7d0188df33f221ad1f0139180f9d", size = 463580, upload-time = "2025-11-26T15:11:44.605Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.41.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/71/70/23b021c950c2addd24ec408e9ab05d59b035b39d97cdc1130e1bce647bb6/pydantic_core-2.41.5.tar.gz", hash = "sha256:08daa51ea16ad373ffd5e7606252cc32f07bc72b28284b6bc9c6df804816476e", size = 460952, upload-time = "2025-11-04T13:43:49.098Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5f/5d/5f6c63eebb5afee93bcaae4ce9a898f3373ca23df3ccaef086d0233a35a7/pydantic_core-2.41.5-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:f41a7489d32336dbf2199c8c0a215390a751c5b014c2c1c5366e817202e9cdf7", size = 2110990, upload-time = "2025-11-04T13:39:58.079Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/32/9c2e8ccb57c01111e0fd091f236c7b371c1bccea0fa85247ac55b1e2b6b6/pydantic_core-2.41.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:070259a8818988b9a84a449a2a7337c7f430a22acc0859c6b110aa7212a6d9c0", size = 1896003, upload-time = "2025-11-04T13:39:59.956Z" },
+    { url = "https://files.pythonhosted.org/packages/68/b8/a01b53cb0e59139fbc9e4fda3e9724ede8de279097179be4ff31f1abb65a/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e96cea19e34778f8d59fe40775a7a574d95816eb150850a85a7a4c8f4b94ac69", size = 1919200, upload-time = "2025-11-04T13:40:02.241Z" },
+    { url = "https://files.pythonhosted.org/packages/38/de/8c36b5198a29bdaade07b5985e80a233a5ac27137846f3bc2d3b40a47360/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ed2e99c456e3fadd05c991f8f437ef902e00eedf34320ba2b0842bd1c3ca3a75", size = 2052578, upload-time = "2025-11-04T13:40:04.401Z" },
+    { url = "https://files.pythonhosted.org/packages/00/b5/0e8e4b5b081eac6cb3dbb7e60a65907549a1ce035a724368c330112adfdd/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:65840751b72fbfd82c3c640cff9284545342a4f1eb1586ad0636955b261b0b05", size = 2208504, upload-time = "2025-11-04T13:40:06.072Z" },
+    { url = "https://files.pythonhosted.org/packages/77/56/87a61aad59c7c5b9dc8caad5a41a5545cba3810c3e828708b3d7404f6cef/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e536c98a7626a98feb2d3eaf75944ef6f3dbee447e1f841eae16f2f0a72d8ddc", size = 2335816, upload-time = "2025-11-04T13:40:07.835Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/76/941cc9f73529988688a665a5c0ecff1112b3d95ab48f81db5f7606f522d3/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eceb81a8d74f9267ef4081e246ffd6d129da5d87e37a77c9bde550cb04870c1c", size = 2075366, upload-time = "2025-11-04T13:40:09.804Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/43/ebef01f69baa07a482844faaa0a591bad1ef129253ffd0cdaa9d8a7f72d3/pydantic_core-2.41.5-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d38548150c39b74aeeb0ce8ee1d8e82696f4a4e16ddc6de7b1d8823f7de4b9b5", size = 2171698, upload-time = "2025-11-04T13:40:12.004Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/87/41f3202e4193e3bacfc2c065fab7706ebe81af46a83d3e27605029c1f5a6/pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:c23e27686783f60290e36827f9c626e63154b82b116d7fe9adba1fda36da706c", size = 2132603, upload-time = "2025-11-04T13:40:13.868Z" },
+    { url = "https://files.pythonhosted.org/packages/49/7d/4c00df99cb12070b6bccdef4a195255e6020a550d572768d92cc54dba91a/pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:482c982f814460eabe1d3bb0adfdc583387bd4691ef00b90575ca0d2b6fe2294", size = 2329591, upload-time = "2025-11-04T13:40:15.672Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/6a/ebf4b1d65d458f3cda6a7335d141305dfa19bdc61140a884d165a8a1bbc7/pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:bfea2a5f0b4d8d43adf9d7b8bf019fb46fdd10a2e5cde477fbcb9d1fa08c68e1", size = 2319068, upload-time = "2025-11-04T13:40:17.532Z" },
+    { url = "https://files.pythonhosted.org/packages/49/3b/774f2b5cd4192d5ab75870ce4381fd89cf218af999515baf07e7206753f0/pydantic_core-2.41.5-cp312-cp312-win32.whl", hash = "sha256:b74557b16e390ec12dca509bce9264c3bbd128f8a2c376eaa68003d7f327276d", size = 1985908, upload-time = "2025-11-04T13:40:19.309Z" },
+    { url = "https://files.pythonhosted.org/packages/86/45/00173a033c801cacf67c190fef088789394feaf88a98a7035b0e40d53dc9/pydantic_core-2.41.5-cp312-cp312-win_amd64.whl", hash = "sha256:1962293292865bca8e54702b08a4f26da73adc83dd1fcf26fbc875b35d81c815", size = 2020145, upload-time = "2025-11-04T13:40:21.548Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/22/91fbc821fa6d261b376a3f73809f907cec5ca6025642c463d3488aad22fb/pydantic_core-2.41.5-cp312-cp312-win_arm64.whl", hash = "sha256:1746d4a3d9a794cacae06a5eaaccb4b8643a131d45fbc9af23e353dc0a5ba5c3", size = 1976179, upload-time = "2025-11-04T13:40:23.393Z" },
+    { url = "https://files.pythonhosted.org/packages/87/06/8806241ff1f70d9939f9af039c6c35f2360cf16e93c2ca76f184e76b1564/pydantic_core-2.41.5-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:941103c9be18ac8daf7b7adca8228f8ed6bb7a1849020f643b3a14d15b1924d9", size = 2120403, upload-time = "2025-11-04T13:40:25.248Z" },
+    { url = "https://files.pythonhosted.org/packages/94/02/abfa0e0bda67faa65fef1c84971c7e45928e108fe24333c81f3bfe35d5f5/pydantic_core-2.41.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:112e305c3314f40c93998e567879e887a3160bb8689ef3d2c04b6cc62c33ac34", size = 1896206, upload-time = "2025-11-04T13:40:27.099Z" },
+    { url = "https://files.pythonhosted.org/packages/15/df/a4c740c0943e93e6500f9eb23f4ca7ec9bf71b19e608ae5b579678c8d02f/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0cbaad15cb0c90aa221d43c00e77bb33c93e8d36e0bf74760cd00e732d10a6a0", size = 1919307, upload-time = "2025-11-04T13:40:29.806Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/e3/6324802931ae1d123528988e0e86587c2072ac2e5394b4bc2bc34b61ff6e/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:03ca43e12fab6023fc79d28ca6b39b05f794ad08ec2feccc59a339b02f2b3d33", size = 2063258, upload-time = "2025-11-04T13:40:33.544Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/d4/2230d7151d4957dd79c3044ea26346c148c98fbf0ee6ebd41056f2d62ab5/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:dc799088c08fa04e43144b164feb0c13f9a0bc40503f8df3e9fde58a3c0c101e", size = 2214917, upload-time = "2025-11-04T13:40:35.479Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/9f/eaac5df17a3672fef0081b6c1bb0b82b33ee89aa5cec0d7b05f52fd4a1fa/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:97aeba56665b4c3235a0e52b2c2f5ae9cd071b8a8310ad27bddb3f7fb30e9aa2", size = 2332186, upload-time = "2025-11-04T13:40:37.436Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/4e/35a80cae583a37cf15604b44240e45c05e04e86f9cfd766623149297e971/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:406bf18d345822d6c21366031003612b9c77b3e29ffdb0f612367352aab7d586", size = 2073164, upload-time = "2025-11-04T13:40:40.289Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/e3/f6e262673c6140dd3305d144d032f7bd5f7497d3871c1428521f19f9efa2/pydantic_core-2.41.5-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:b93590ae81f7010dbe380cdeab6f515902ebcbefe0b9327cc4804d74e93ae69d", size = 2179146, upload-time = "2025-11-04T13:40:42.809Z" },
+    { url = "https://files.pythonhosted.org/packages/75/c7/20bd7fc05f0c6ea2056a4565c6f36f8968c0924f19b7d97bbfea55780e73/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:01a3d0ab748ee531f4ea6c3e48ad9dac84ddba4b0d82291f87248f2f9de8d740", size = 2137788, upload-time = "2025-11-04T13:40:44.752Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/8d/34318ef985c45196e004bc46c6eab2eda437e744c124ef0dbe1ff2c9d06b/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:6561e94ba9dacc9c61bce40e2d6bdc3bfaa0259d3ff36ace3b1e6901936d2e3e", size = 2340133, upload-time = "2025-11-04T13:40:46.66Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/59/013626bf8c78a5a5d9350d12e7697d3d4de951a75565496abd40ccd46bee/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:915c3d10f81bec3a74fbd4faebe8391013ba61e5a1a8d48c4455b923bdda7858", size = 2324852, upload-time = "2025-11-04T13:40:48.575Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/d9/c248c103856f807ef70c18a4f986693a46a8ffe1602e5d361485da502d20/pydantic_core-2.41.5-cp313-cp313-win32.whl", hash = "sha256:650ae77860b45cfa6e2cdafc42618ceafab3a2d9a3811fcfbd3bbf8ac3c40d36", size = 1994679, upload-time = "2025-11-04T13:40:50.619Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/8b/341991b158ddab181cff136acd2552c9f35bd30380422a639c0671e99a91/pydantic_core-2.41.5-cp313-cp313-win_amd64.whl", hash = "sha256:79ec52ec461e99e13791ec6508c722742ad745571f234ea6255bed38c6480f11", size = 2019766, upload-time = "2025-11-04T13:40:52.631Z" },
+    { url = "https://files.pythonhosted.org/packages/73/7d/f2f9db34af103bea3e09735bb40b021788a5e834c81eedb541991badf8f5/pydantic_core-2.41.5-cp313-cp313-win_arm64.whl", hash = "sha256:3f84d5c1b4ab906093bdc1ff10484838aca54ef08de4afa9de0f5f14d69639cd", size = 1981005, upload-time = "2025-11-04T13:40:54.734Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/28/46b7c5c9635ae96ea0fbb779e271a38129df2550f763937659ee6c5dbc65/pydantic_core-2.41.5-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:3f37a19d7ebcdd20b96485056ba9e8b304e27d9904d233d7b1015db320e51f0a", size = 2119622, upload-time = "2025-11-04T13:40:56.68Z" },
+    { url = "https://files.pythonhosted.org/packages/74/1a/145646e5687e8d9a1e8d09acb278c8535ebe9e972e1f162ed338a622f193/pydantic_core-2.41.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1d1d9764366c73f996edd17abb6d9d7649a7eb690006ab6adbda117717099b14", size = 1891725, upload-time = "2025-11-04T13:40:58.807Z" },
+    { url = "https://files.pythonhosted.org/packages/23/04/e89c29e267b8060b40dca97bfc64a19b2a3cf99018167ea1677d96368273/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:25e1c2af0fce638d5f1988b686f3b3ea8cd7de5f244ca147c777769e798a9cd1", size = 1915040, upload-time = "2025-11-04T13:41:00.853Z" },
+    { url = "https://files.pythonhosted.org/packages/84/a3/15a82ac7bd97992a82257f777b3583d3e84bdb06ba6858f745daa2ec8a85/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:506d766a8727beef16b7adaeb8ee6217c64fc813646b424d0804d67c16eddb66", size = 2063691, upload-time = "2025-11-04T13:41:03.504Z" },
+    { url = "https://files.pythonhosted.org/packages/74/9b/0046701313c6ef08c0c1cf0e028c67c770a4e1275ca73131563c5f2a310a/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4819fa52133c9aa3c387b3328f25c1facc356491e6135b459f1de698ff64d869", size = 2213897, upload-time = "2025-11-04T13:41:05.804Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/cd/6bac76ecd1b27e75a95ca3a9a559c643b3afcd2dd62086d4b7a32a18b169/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2b761d210c9ea91feda40d25b4efe82a1707da2ef62901466a42492c028553a2", size = 2333302, upload-time = "2025-11-04T13:41:07.809Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/d2/ef2074dc020dd6e109611a8be4449b98cd25e1b9b8a303c2f0fca2f2bcf7/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:22f0fb8c1c583a3b6f24df2470833b40207e907b90c928cc8d3594b76f874375", size = 2064877, upload-time = "2025-11-04T13:41:09.827Z" },
+    { url = "https://files.pythonhosted.org/packages/18/66/e9db17a9a763d72f03de903883c057b2592c09509ccfe468187f2a2eef29/pydantic_core-2.41.5-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2782c870e99878c634505236d81e5443092fba820f0373997ff75f90f68cd553", size = 2180680, upload-time = "2025-11-04T13:41:12.379Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/9e/3ce66cebb929f3ced22be85d4c2399b8e85b622db77dad36b73c5387f8f8/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:0177272f88ab8312479336e1d777f6b124537d47f2123f89cb37e0accea97f90", size = 2138960, upload-time = "2025-11-04T13:41:14.627Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/62/205a998f4327d2079326b01abee48e502ea739d174f0a89295c481a2272e/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:63510af5e38f8955b8ee5687740d6ebf7c2a0886d15a6d65c32814613681bc07", size = 2339102, upload-time = "2025-11-04T13:41:16.868Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/0d/f05e79471e889d74d3d88f5bd20d0ed189ad94c2423d81ff8d0000aab4ff/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:e56ba91f47764cc14f1daacd723e3e82d1a89d783f0f5afe9c364b8bb491ccdb", size = 2326039, upload-time = "2025-11-04T13:41:18.934Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/e1/e08a6208bb100da7e0c4b288eed624a703f4d129bde2da475721a80cab32/pydantic_core-2.41.5-cp314-cp314-win32.whl", hash = "sha256:aec5cf2fd867b4ff45b9959f8b20ea3993fc93e63c7363fe6851424c8a7e7c23", size = 1995126, upload-time = "2025-11-04T13:41:21.418Z" },
+    { url = "https://files.pythonhosted.org/packages/48/5d/56ba7b24e9557f99c9237e29f5c09913c81eeb2f3217e40e922353668092/pydantic_core-2.41.5-cp314-cp314-win_amd64.whl", hash = "sha256:8e7c86f27c585ef37c35e56a96363ab8de4e549a95512445b85c96d3e2f7c1bf", size = 2015489, upload-time = "2025-11-04T13:41:24.076Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/bb/f7a190991ec9e3e0ba22e4993d8755bbc4a32925c0b5b42775c03e8148f9/pydantic_core-2.41.5-cp314-cp314-win_arm64.whl", hash = "sha256:e672ba74fbc2dc8eea59fb6d4aed6845e6905fc2a8afe93175d94a83ba2a01a0", size = 1977288, upload-time = "2025-11-04T13:41:26.33Z" },
+    { url = "https://files.pythonhosted.org/packages/92/ed/77542d0c51538e32e15afe7899d79efce4b81eee631d99850edc2f5e9349/pydantic_core-2.41.5-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:8566def80554c3faa0e65ac30ab0932b9e3a5cd7f8323764303d468e5c37595a", size = 2120255, upload-time = "2025-11-04T13:41:28.569Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/3d/6913dde84d5be21e284439676168b28d8bbba5600d838b9dca99de0fad71/pydantic_core-2.41.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:b80aa5095cd3109962a298ce14110ae16b8c1aece8b72f9dafe81cf597ad80b3", size = 1863760, upload-time = "2025-11-04T13:41:31.055Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/f0/e5e6b99d4191da102f2b0eb9687aaa7f5bea5d9964071a84effc3e40f997/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3006c3dd9ba34b0c094c544c6006cc79e87d8612999f1a5d43b769b89181f23c", size = 1878092, upload-time = "2025-11-04T13:41:33.21Z" },
+    { url = "https://files.pythonhosted.org/packages/71/48/36fb760642d568925953bcc8116455513d6e34c4beaa37544118c36aba6d/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:72f6c8b11857a856bcfa48c86f5368439f74453563f951e473514579d44aa612", size = 2053385, upload-time = "2025-11-04T13:41:35.508Z" },
+    { url = "https://files.pythonhosted.org/packages/20/25/92dc684dd8eb75a234bc1c764b4210cf2646479d54b47bf46061657292a8/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5cb1b2f9742240e4bb26b652a5aeb840aa4b417c7748b6f8387927bc6e45e40d", size = 2218832, upload-time = "2025-11-04T13:41:37.732Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/09/f53e0b05023d3e30357d82eb35835d0f6340ca344720a4599cd663dca599/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bd3d54f38609ff308209bd43acea66061494157703364ae40c951f83ba99a1a9", size = 2327585, upload-time = "2025-11-04T13:41:40Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/4e/2ae1aa85d6af35a39b236b1b1641de73f5a6ac4d5a7509f77b814885760c/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2ff4321e56e879ee8d2a879501c8e469414d948f4aba74a2d4593184eb326660", size = 2041078, upload-time = "2025-11-04T13:41:42.323Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/13/2e215f17f0ef326fc72afe94776edb77525142c693767fc347ed6288728d/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d0d2568a8c11bf8225044aa94409e21da0cb09dcdafe9ecd10250b2baad531a9", size = 2173914, upload-time = "2025-11-04T13:41:45.221Z" },
+    { url = "https://files.pythonhosted.org/packages/02/7a/f999a6dcbcd0e5660bc348a3991c8915ce6599f4f2c6ac22f01d7a10816c/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:a39455728aabd58ceabb03c90e12f71fd30fa69615760a075b9fec596456ccc3", size = 2129560, upload-time = "2025-11-04T13:41:47.474Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/b1/6c990ac65e3b4c079a4fb9f5b05f5b013afa0f4ed6780a3dd236d2cbdc64/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:239edca560d05757817c13dc17c50766136d21f7cd0fac50295499ae24f90fdf", size = 2329244, upload-time = "2025-11-04T13:41:49.992Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/02/3c562f3a51afd4d88fff8dffb1771b30cfdfd79befd9883ee094f5b6c0d8/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:2a5e06546e19f24c6a96a129142a75cee553cc018ffee48a460059b1185f4470", size = 2331955, upload-time = "2025-11-04T13:41:54.079Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/96/5fb7d8c3c17bc8c62fdb031c47d77a1af698f1d7a406b0f79aaa1338f9ad/pydantic_core-2.41.5-cp314-cp314t-win32.whl", hash = "sha256:b4ececa40ac28afa90871c2cc2b9ffd2ff0bf749380fbdf57d165fd23da353aa", size = 1988906, upload-time = "2025-11-04T13:41:56.606Z" },
+    { url = "https://files.pythonhosted.org/packages/22/ed/182129d83032702912c2e2d8bbe33c036f342cc735737064668585dac28f/pydantic_core-2.41.5-cp314-cp314t-win_amd64.whl", hash = "sha256:80aa89cad80b32a912a65332f64a4450ed00966111b6615ca6816153d3585a8c", size = 1981607, upload-time = "2025-11-04T13:41:58.889Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/ed/068e41660b832bb0b1aa5b58011dea2a3fe0ba7861ff38c4d4904c1c1a99/pydantic_core-2.41.5-cp314-cp314t-win_arm64.whl", hash = "sha256:35b44f37a3199f771c3eaa53051bc8a70cd7b54f333531c59e29fd4db5d15008", size = 1974769, upload-time = "2025-11-04T13:42:01.186Z" },
+    { url = "https://files.pythonhosted.org/packages/09/32/59b0c7e63e277fa7911c2fc70ccfb45ce4b98991e7ef37110663437005af/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:7da7087d756b19037bc2c06edc6c170eeef3c3bafcb8f532ff17d64dc427adfd", size = 2110495, upload-time = "2025-11-04T13:42:49.689Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/81/05e400037eaf55ad400bcd318c05bb345b57e708887f07ddb2d20e3f0e98/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:aabf5777b5c8ca26f7824cb4a120a740c9588ed58df9b2d196ce92fba42ff8dc", size = 1915388, upload-time = "2025-11-04T13:42:52.215Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/0d/e3549b2399f71d56476b77dbf3cf8937cec5cd70536bdc0e374a421d0599/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c007fe8a43d43b3969e8469004e9845944f1a80e6acd47c150856bb87f230c56", size = 1942879, upload-time = "2025-11-04T13:42:56.483Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/07/34573da085946b6a313d7c42f82f16e8920bfd730665de2d11c0c37a74b5/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:76d0819de158cd855d1cbb8fcafdf6f5cf1eb8e470abe056d5d161106e38062b", size = 2139017, upload-time = "2025-11-04T13:42:59.471Z" },
+]
+
+[[package]]
+name = "pyee"
+version = "13.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/04/e7c1fe4dc78a6fdbfd6c337b1c3732ff543b8a397683ab38378447baa331/pyee-13.0.1.tar.gz", hash = "sha256:0b931f7c14535667ed4c7e0d531716368715e860b988770fc7eb8578d1f67fc8", size = 31655, upload-time = "2026-02-14T21:12:28.044Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/c4/b4d4827c93ef43c01f599ef31453ccc1c132b353284fc6c87d535c233129/pyee-13.0.1-py3-none-any.whl", hash = "sha256:af2f8fede4171ef667dfded53f96e2ed0d6e6bd7ee3bb46437f77e3b57689228", size = 15659, upload-time = "2026-02-14T21:12:26.263Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pyte"
+version = "0.8.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ab/ab/b599762933eba04de7dc5b31ae083112a6c9a9db15b01d3109ad797559d9/pyte-0.8.2.tar.gz", hash = "sha256:5af970e843fa96a97149d64e170c984721f20e52227a2f57f0a54207f08f083f", size = 92301, upload-time = "2023-11-12T09:33:43.217Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/59/d0/bb522283b90853afbf506cd5b71c650cf708829914efd0003d615cf426cd/pyte-0.8.2-py3-none-any.whl", hash = "sha256:85db42a35798a5aafa96ac4d8da78b090b2c933248819157fc0e6f78876a0135", size = 31627, upload-time = "2023-11-12T09:33:41.096Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
+]
+
+[[package]]
+name = "python-dotenv"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
+    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
+    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "starlette"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "uuid6"
+version = "2025.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ca/b7/4c0f736ca824b3a25b15e8213d1bcfc15f8ac2ae48d1b445b310892dc4da/uuid6-2025.0.1.tar.gz", hash = "sha256:cd0af94fa428675a44e32c5319ec5a3485225ba2179eefcf4c3f205ae30a81bd", size = 13932, upload-time = "2025-07-04T18:30:35.186Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3d/b2/93faaab7962e2aa8d6e174afb6f76be2ca0ce89fde14d3af835acebcaa59/uuid6-2025.0.1-py3-none-any.whl", hash = "sha256:80530ce4d02a93cdf82e7122ca0da3ebbbc269790ec1cb902481fa3e9cc9ff99", size = 6979, upload-time = "2025-07-04T18:30:34.001Z" },
+]
+
+[[package]]
+name = "uvicorn"
+version = "0.42.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e3/ad/4a96c425be6fb67e0621e62d86c402b4a17ab2be7f7c055d9bd2f638b9e2/uvicorn-0.42.0.tar.gz", hash = "sha256:9b1f190ce15a2dd22e7758651d9b6d12df09a13d51ba5bf4fc33c383a48e1775", size = 85393, upload-time = "2026-03-16T06:19:50.077Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0a/89/f8827ccff89c1586027a105e5630ff6139a64da2515e24dafe860bd9ae4d/uvicorn-0.42.0-py3-none-any.whl", hash = "sha256:96c30f5c7abe6f74ae8900a70e92b85ad6613b745d4879eb9b16ccad15645359", size = 68830, upload-time = "2026-03-16T06:19:48.325Z" },
+]
+
+[package.optional-dependencies]
+standard = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "httptools" },
+    { name = "python-dotenv" },
+    { name = "pyyaml" },
+    { name = "uvloop", marker = "platform_python_implementation != 'PyPy' and sys_platform != 'cygwin' and sys_platform != 'win32'" },
+    { name = "watchfiles" },
+    { name = "websockets" },
+]
+
+[[package]]
+name = "uvloop"
+version = "0.22.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/06/f0/18d39dbd1971d6d62c4629cc7fa67f74821b0dc1f5a77af43719de7936a7/uvloop-0.22.1.tar.gz", hash = "sha256:6c84bae345b9147082b17371e3dd5d42775bddce91f885499017f4607fdaf39f", size = 2443250, upload-time = "2025-10-16T22:17:19.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3d/ff/7f72e8170be527b4977b033239a83a68d5c881cc4775fca255c677f7ac5d/uvloop-0.22.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:fe94b4564e865d968414598eea1a6de60adba0c040ba4ed05ac1300de402cd42", size = 1359936, upload-time = "2025-10-16T22:16:29.436Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/c6/e5d433f88fd54d81ef4be58b2b7b0cea13c442454a1db703a1eea0db1a59/uvloop-0.22.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:51eb9bd88391483410daad430813d982010f9c9c89512321f5b60e2cddbdddd6", size = 752769, upload-time = "2025-10-16T22:16:30.493Z" },
+    { url = "https://files.pythonhosted.org/packages/24/68/a6ac446820273e71aa762fa21cdcc09861edd3536ff47c5cd3b7afb10eeb/uvloop-0.22.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:700e674a166ca5778255e0e1dc4e9d79ab2acc57b9171b79e65feba7184b3370", size = 4317413, upload-time = "2025-10-16T22:16:31.644Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/6f/e62b4dfc7ad6518e7eff2516f680d02a0f6eb62c0c212e152ca708a0085e/uvloop-0.22.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7b5b1ac819a3f946d3b2ee07f09149578ae76066d70b44df3fa990add49a82e4", size = 4426307, upload-time = "2025-10-16T22:16:32.917Z" },
+    { url = "https://files.pythonhosted.org/packages/90/60/97362554ac21e20e81bcef1150cb2a7e4ffdaf8ea1e5b2e8bf7a053caa18/uvloop-0.22.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e047cc068570bac9866237739607d1313b9253c3051ad84738cbb095be0537b2", size = 4131970, upload-time = "2025-10-16T22:16:34.015Z" },
+    { url = "https://files.pythonhosted.org/packages/99/39/6b3f7d234ba3964c428a6e40006340f53ba37993f46ed6e111c6e9141d18/uvloop-0.22.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:512fec6815e2dd45161054592441ef76c830eddaad55c8aa30952e6fe1ed07c0", size = 4296343, upload-time = "2025-10-16T22:16:35.149Z" },
+    { url = "https://files.pythonhosted.org/packages/89/8c/182a2a593195bfd39842ea68ebc084e20c850806117213f5a299dfc513d9/uvloop-0.22.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:561577354eb94200d75aca23fbde86ee11be36b00e52a4eaf8f50fb0c86b7705", size = 1358611, upload-time = "2025-10-16T22:16:36.833Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/14/e301ee96a6dc95224b6f1162cd3312f6d1217be3907b79173b06785f2fe7/uvloop-0.22.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:1cdf5192ab3e674ca26da2eada35b288d2fa49fdd0f357a19f0e7c4e7d5077c8", size = 751811, upload-time = "2025-10-16T22:16:38.275Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/02/654426ce265ac19e2980bfd9ea6590ca96a56f10c76e63801a2df01c0486/uvloop-0.22.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6e2ea3d6190a2968f4a14a23019d3b16870dd2190cd69c8180f7c632d21de68d", size = 4288562, upload-time = "2025-10-16T22:16:39.375Z" },
+    { url = "https://files.pythonhosted.org/packages/15/c0/0be24758891ef825f2065cd5db8741aaddabe3e248ee6acc5e8a80f04005/uvloop-0.22.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0530a5fbad9c9e4ee3f2b33b148c6a64d47bbad8000ea63704fa8260f4cf728e", size = 4366890, upload-time = "2025-10-16T22:16:40.547Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/53/8369e5219a5855869bcee5f4d317f6da0e2c669aecf0ef7d371e3d084449/uvloop-0.22.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:bc5ef13bbc10b5335792360623cc378d52d7e62c2de64660616478c32cd0598e", size = 4119472, upload-time = "2025-10-16T22:16:41.694Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ba/d69adbe699b768f6b29a5eec7b47dd610bd17a69de51b251126a801369ea/uvloop-0.22.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1f38ec5e3f18c8a10ded09742f7fb8de0108796eb673f30ce7762ce1b8550cad", size = 4239051, upload-time = "2025-10-16T22:16:43.224Z" },
+    { url = "https://files.pythonhosted.org/packages/90/cd/b62bdeaa429758aee8de8b00ac0dd26593a9de93d302bff3d21439e9791d/uvloop-0.22.1-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:3879b88423ec7e97cd4eba2a443aa26ed4e59b45e6b76aabf13fe2f27023a142", size = 1362067, upload-time = "2025-10-16T22:16:44.503Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/f8/a132124dfda0777e489ca86732e85e69afcd1ff7686647000050ba670689/uvloop-0.22.1-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:4baa86acedf1d62115c1dc6ad1e17134476688f08c6efd8a2ab076e815665c74", size = 752423, upload-time = "2025-10-16T22:16:45.968Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/94/94af78c156f88da4b3a733773ad5ba0b164393e357cc4bd0ab2e2677a7d6/uvloop-0.22.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:297c27d8003520596236bdb2335e6b3f649480bd09e00d1e3a99144b691d2a35", size = 4272437, upload-time = "2025-10-16T22:16:47.451Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/35/60249e9fd07b32c665192cec7af29e06c7cd96fa1d08b84f012a56a0b38e/uvloop-0.22.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c1955d5a1dd43198244d47664a5858082a3239766a839b2102a269aaff7a4e25", size = 4292101, upload-time = "2025-10-16T22:16:49.318Z" },
+    { url = "https://files.pythonhosted.org/packages/02/62/67d382dfcb25d0a98ce73c11ed1a6fba5037a1a1d533dcbb7cab033a2636/uvloop-0.22.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:b31dc2fccbd42adc73bc4e7cdbae4fc5086cf378979e53ca5d0301838c5682c6", size = 4114158, upload-time = "2025-10-16T22:16:50.517Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/f1171b4a882a5d13c8b7576f348acfe6074d72eaf52cccef752f748d4a9f/uvloop-0.22.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:93f617675b2d03af4e72a5333ef89450dfaa5321303ede6e67ba9c9d26878079", size = 4177360, upload-time = "2025-10-16T22:16:52.646Z" },
+    { url = "https://files.pythonhosted.org/packages/79/7b/b01414f31546caf0919da80ad57cbfe24c56b151d12af68cee1b04922ca8/uvloop-0.22.1-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:37554f70528f60cad66945b885eb01f1bb514f132d92b6eeed1c90fd54ed6289", size = 1454790, upload-time = "2025-10-16T22:16:54.355Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/31/0bb232318dd838cad3fa8fb0c68c8b40e1145b32025581975e18b11fab40/uvloop-0.22.1-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:b76324e2dc033a0b2f435f33eb88ff9913c156ef78e153fb210e03c13da746b3", size = 796783, upload-time = "2025-10-16T22:16:55.906Z" },
+    { url = "https://files.pythonhosted.org/packages/42/38/c9b09f3271a7a723a5de69f8e237ab8e7803183131bc57c890db0b6bb872/uvloop-0.22.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:badb4d8e58ee08dad957002027830d5c3b06aea446a6a3744483c2b3b745345c", size = 4647548, upload-time = "2025-10-16T22:16:57.008Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/37/945b4ca0ac27e3dc4952642d4c900edd030b3da6c9634875af6e13ae80e5/uvloop-0.22.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b91328c72635f6f9e0282e4a57da7470c7350ab1c9f48546c0f2866205349d21", size = 4467065, upload-time = "2025-10-16T22:16:58.206Z" },
+    { url = "https://files.pythonhosted.org/packages/97/cc/48d232f33d60e2e2e0b42f4e73455b146b76ebe216487e862700457fbf3c/uvloop-0.22.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:daf620c2995d193449393d6c62131b3fbd40a63bf7b307a1527856ace637fe88", size = 4328384, upload-time = "2025-10-16T22:16:59.36Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/16/c1fd27e9549f3c4baf1dc9c20c456cd2f822dbf8de9f463824b0c0357e06/uvloop-0.22.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6cde23eeda1a25c75b2e07d39970f3374105d5eafbaab2a4482be82f272d5a5e", size = 4296730, upload-time = "2025-10-16T22:17:00.744Z" },
+]
+
+[[package]]
+name = "watchfiles"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c2/c9/8869df9b2a2d6c59d79220a4db37679e74f807c559ffe5265e08b227a210/watchfiles-1.1.1.tar.gz", hash = "sha256:a173cb5c16c4f40ab19cecf48a534c409f7ea983ab8fed0741304a1c0a31b3f2", size = 94440, upload-time = "2025-10-14T15:06:21.08Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/74/d5/f039e7e3c639d9b1d09b07ea412a6806d38123f0508e5f9b48a87b0a76cc/watchfiles-1.1.1-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:8c89f9f2f740a6b7dcc753140dd5e1ab9215966f7a3530d0c0705c83b401bd7d", size = 404745, upload-time = "2025-10-14T15:04:46.731Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/96/a881a13aa1349827490dab2d363c8039527060cfcc2c92cc6d13d1b1049e/watchfiles-1.1.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:bd404be08018c37350f0d6e34676bd1e2889990117a2b90070b3007f172d0610", size = 391769, upload-time = "2025-10-14T15:04:48.003Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/5b/d3b460364aeb8da471c1989238ea0e56bec24b6042a68046adf3d9ddb01c/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8526e8f916bb5b9a0a777c8317c23ce65de259422bba5b31325a6fa6029d33af", size = 449374, upload-time = "2025-10-14T15:04:49.179Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/44/5769cb62d4ed055cb17417c0a109a92f007114a4e07f30812a73a4efdb11/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2edc3553362b1c38d9f06242416a5d8e9fe235c204a4072e988ce2e5bb1f69f6", size = 459485, upload-time = "2025-10-14T15:04:50.155Z" },
+    { url = "https://files.pythonhosted.org/packages/19/0c/286b6301ded2eccd4ffd0041a1b726afda999926cf720aab63adb68a1e36/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:30f7da3fb3f2844259cba4720c3fc7138eb0f7b659c38f3bfa65084c7fc7abce", size = 488813, upload-time = "2025-10-14T15:04:51.059Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/2b/8530ed41112dd4a22f4dcfdb5ccf6a1baad1ff6eed8dc5a5f09e7e8c41c7/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f8979280bdafff686ba5e4d8f97840f929a87ed9cdf133cbbd42f7766774d2aa", size = 594816, upload-time = "2025-10-14T15:04:52.031Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/d2/f5f9fb49489f184f18470d4f99f4e862a4b3e9ac2865688eb2099e3d837a/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:dcc5c24523771db3a294c77d94771abcfcb82a0e0ee8efd910c37c59ec1b31bb", size = 475186, upload-time = "2025-10-14T15:04:53.064Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/68/5707da262a119fb06fbe214d82dd1fe4a6f4af32d2d14de368d0349eb52a/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1db5d7ae38ff20153d542460752ff397fcf5c96090c1230803713cf3147a6803", size = 456812, upload-time = "2025-10-14T15:04:55.174Z" },
+    { url = "https://files.pythonhosted.org/packages/66/ab/3cbb8756323e8f9b6f9acb9ef4ec26d42b2109bce830cc1f3468df20511d/watchfiles-1.1.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:28475ddbde92df1874b6c5c8aaeb24ad5be47a11f87cde5a28ef3835932e3e94", size = 630196, upload-time = "2025-10-14T15:04:56.22Z" },
+    { url = "https://files.pythonhosted.org/packages/78/46/7152ec29b8335f80167928944a94955015a345440f524d2dfe63fc2f437b/watchfiles-1.1.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:36193ed342f5b9842edd3532729a2ad55c4160ffcfa3700e0d54be496b70dd43", size = 622657, upload-time = "2025-10-14T15:04:57.521Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/bf/95895e78dd75efe9a7f31733607f384b42eb5feb54bd2eb6ed57cc2e94f4/watchfiles-1.1.1-cp312-cp312-win32.whl", hash = "sha256:859e43a1951717cc8de7f4c77674a6d389b106361585951d9e69572823f311d9", size = 272042, upload-time = "2025-10-14T15:04:59.046Z" },
+    { url = "https://files.pythonhosted.org/packages/87/0a/90eb755f568de2688cb220171c4191df932232c20946966c27a59c400850/watchfiles-1.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:91d4c9a823a8c987cce8fa2690923b069966dabb196dd8d137ea2cede885fde9", size = 288410, upload-time = "2025-10-14T15:05:00.081Z" },
+    { url = "https://files.pythonhosted.org/packages/36/76/f322701530586922fbd6723c4f91ace21364924822a8772c549483abed13/watchfiles-1.1.1-cp312-cp312-win_arm64.whl", hash = "sha256:a625815d4a2bdca61953dbba5a39d60164451ef34c88d751f6c368c3ea73d404", size = 278209, upload-time = "2025-10-14T15:05:01.168Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/f4/f750b29225fe77139f7ae5de89d4949f5a99f934c65a1f1c0b248f26f747/watchfiles-1.1.1-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:130e4876309e8686a5e37dba7d5e9bc77e6ed908266996ca26572437a5271e18", size = 404321, upload-time = "2025-10-14T15:05:02.063Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/f9/f07a295cde762644aa4c4bb0f88921d2d141af45e735b965fb2e87858328/watchfiles-1.1.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:5f3bde70f157f84ece3765b42b4a52c6ac1a50334903c6eaf765362f6ccca88a", size = 391783, upload-time = "2025-10-14T15:05:03.052Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/11/fc2502457e0bea39a5c958d86d2cb69e407a4d00b85735ca724bfa6e0d1a/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:14e0b1fe858430fc0251737ef3824c54027bedb8c37c38114488b8e131cf8219", size = 449279, upload-time = "2025-10-14T15:05:04.004Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/1f/d66bc15ea0b728df3ed96a539c777acfcad0eb78555ad9efcaa1274688f0/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f27db948078f3823a6bb3b465180db8ebecf26dd5dae6f6180bd87383b6b4428", size = 459405, upload-time = "2025-10-14T15:05:04.942Z" },
+    { url = "https://files.pythonhosted.org/packages/be/90/9f4a65c0aec3ccf032703e6db02d89a157462fbb2cf20dd415128251cac0/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:059098c3a429f62fc98e8ec62b982230ef2c8df68c79e826e37b895bc359a9c0", size = 488976, upload-time = "2025-10-14T15:05:05.905Z" },
+    { url = "https://files.pythonhosted.org/packages/37/57/ee347af605d867f712be7029bb94c8c071732a4b44792e3176fa3c612d39/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:bfb5862016acc9b869bb57284e6cb35fdf8e22fe59f7548858e2f971d045f150", size = 595506, upload-time = "2025-10-14T15:05:06.906Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/78/cc5ab0b86c122047f75e8fc471c67a04dee395daf847d3e59381996c8707/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:319b27255aacd9923b8a276bb14d21a5f7ff82564c744235fc5eae58d95422ae", size = 474936, upload-time = "2025-10-14T15:05:07.906Z" },
+    { url = "https://files.pythonhosted.org/packages/62/da/def65b170a3815af7bd40a3e7010bf6ab53089ef1b75d05dd5385b87cf08/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c755367e51db90e75b19454b680903631d41f9e3607fbd941d296a020c2d752d", size = 456147, upload-time = "2025-10-14T15:05:09.138Z" },
+    { url = "https://files.pythonhosted.org/packages/57/99/da6573ba71166e82d288d4df0839128004c67d2778d3b566c138695f5c0b/watchfiles-1.1.1-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:c22c776292a23bfc7237a98f791b9ad3144b02116ff10d820829ce62dff46d0b", size = 630007, upload-time = "2025-10-14T15:05:10.117Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/51/7439c4dd39511368849eb1e53279cd3454b4a4dbace80bab88feeb83c6b5/watchfiles-1.1.1-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:3a476189be23c3686bc2f4321dd501cb329c0a0469e77b7b534ee10129ae6374", size = 622280, upload-time = "2025-10-14T15:05:11.146Z" },
+    { url = "https://files.pythonhosted.org/packages/95/9c/8ed97d4bba5db6fdcdb2b298d3898f2dd5c20f6b73aee04eabe56c59677e/watchfiles-1.1.1-cp313-cp313-win32.whl", hash = "sha256:bf0a91bfb5574a2f7fc223cf95eeea79abfefa404bf1ea5e339c0c1560ae99a0", size = 272056, upload-time = "2025-10-14T15:05:12.156Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f3/c14e28429f744a260d8ceae18bf58c1d5fa56b50d006a7a9f80e1882cb0d/watchfiles-1.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:52e06553899e11e8074503c8e716d574adeeb7e68913115c4b3653c53f9bae42", size = 288162, upload-time = "2025-10-14T15:05:13.208Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/61/fe0e56c40d5cd29523e398d31153218718c5786b5e636d9ae8ae79453d27/watchfiles-1.1.1-cp313-cp313-win_arm64.whl", hash = "sha256:ac3cc5759570cd02662b15fbcd9d917f7ecd47efe0d6b40474eafd246f91ea18", size = 277909, upload-time = "2025-10-14T15:05:14.49Z" },
+    { url = "https://files.pythonhosted.org/packages/79/42/e0a7d749626f1e28c7108a99fb9bf524b501bbbeb9b261ceecde644d5a07/watchfiles-1.1.1-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:563b116874a9a7ce6f96f87cd0b94f7faf92d08d0021e837796f0a14318ef8da", size = 403389, upload-time = "2025-10-14T15:05:15.777Z" },
+    { url = "https://files.pythonhosted.org/packages/15/49/08732f90ce0fbbc13913f9f215c689cfc9ced345fb1bcd8829a50007cc8d/watchfiles-1.1.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3ad9fe1dae4ab4212d8c91e80b832425e24f421703b5a42ef2e4a1e215aff051", size = 389964, upload-time = "2025-10-14T15:05:16.85Z" },
+    { url = "https://files.pythonhosted.org/packages/27/0d/7c315d4bd5f2538910491a0393c56bf70d333d51bc5b34bee8e68e8cea19/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce70f96a46b894b36eba678f153f052967a0d06d5b5a19b336ab0dbbd029f73e", size = 448114, upload-time = "2025-10-14T15:05:17.876Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/24/9e096de47a4d11bc4df41e9d1e61776393eac4cb6eb11b3e23315b78b2cc/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:cb467c999c2eff23a6417e58d75e5828716f42ed8289fe6b77a7e5a91036ca70", size = 460264, upload-time = "2025-10-14T15:05:18.962Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/0f/e8dea6375f1d3ba5fcb0b3583e2b493e77379834c74fd5a22d66d85d6540/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:836398932192dae4146c8f6f737d74baeac8b70ce14831a239bdb1ca882fc261", size = 487877, upload-time = "2025-10-14T15:05:20.094Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/5b/df24cfc6424a12deb41503b64d42fbea6b8cb357ec62ca84a5a3476f654a/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:743185e7372b7bc7c389e1badcc606931a827112fbbd37f14c537320fca08620", size = 595176, upload-time = "2025-10-14T15:05:21.134Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/b5/853b6757f7347de4e9b37e8cc3289283fb983cba1ab4d2d7144694871d9c/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:afaeff7696e0ad9f02cbb8f56365ff4686ab205fcf9c4c5b6fdfaaa16549dd04", size = 473577, upload-time = "2025-10-14T15:05:22.306Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/f7/0a4467be0a56e80447c8529c9fce5b38eab4f513cb3d9bf82e7392a5696b/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3f7eb7da0eb23aa2ba036d4f616d46906013a68caf61b7fdbe42fc8b25132e77", size = 455425, upload-time = "2025-10-14T15:05:23.348Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/e0/82583485ea00137ddf69bc84a2db88bd92ab4a6e3c405e5fb878ead8d0e7/watchfiles-1.1.1-cp313-cp313t-musllinux_1_1_aarch64.whl", hash = "sha256:831a62658609f0e5c64178211c942ace999517f5770fe9436be4c2faeba0c0ef", size = 628826, upload-time = "2025-10-14T15:05:24.398Z" },
+    { url = "https://files.pythonhosted.org/packages/28/9a/a785356fccf9fae84c0cc90570f11702ae9571036fb25932f1242c82191c/watchfiles-1.1.1-cp313-cp313t-musllinux_1_1_x86_64.whl", hash = "sha256:f9a2ae5c91cecc9edd47e041a930490c31c3afb1f5e6d71de3dc671bfaca02bf", size = 622208, upload-time = "2025-10-14T15:05:25.45Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/f4/0872229324ef69b2c3edec35e84bd57a1289e7d3fe74588048ed8947a323/watchfiles-1.1.1-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:d1715143123baeeaeadec0528bb7441103979a1d5f6fd0e1f915383fea7ea6d5", size = 404315, upload-time = "2025-10-14T15:05:26.501Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/22/16d5331eaed1cb107b873f6ae1b69e9ced582fcf0c59a50cd84f403b1c32/watchfiles-1.1.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:39574d6370c4579d7f5d0ad940ce5b20db0e4117444e39b6d8f99db5676c52fd", size = 390869, upload-time = "2025-10-14T15:05:27.649Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/7e/5643bfff5acb6539b18483128fdc0ef2cccc94a5b8fbda130c823e8ed636/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7365b92c2e69ee952902e8f70f3ba6360d0d596d9299d55d7d386df84b6941fb", size = 449919, upload-time = "2025-10-14T15:05:28.701Z" },
+    { url = "https://files.pythonhosted.org/packages/51/2e/c410993ba5025a9f9357c376f48976ef0e1b1aefb73b97a5ae01a5972755/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bfff9740c69c0e4ed32416f013f3c45e2ae42ccedd1167ef2d805c000b6c71a5", size = 460845, upload-time = "2025-10-14T15:05:30.064Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/a4/2df3b404469122e8680f0fcd06079317e48db58a2da2950fb45020947734/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b27cf2eb1dda37b2089e3907d8ea92922b673c0c427886d4edc6b94d8dfe5db3", size = 489027, upload-time = "2025-10-14T15:05:31.064Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/84/4587ba5b1f267167ee715b7f66e6382cca6938e0a4b870adad93e44747e6/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:526e86aced14a65a5b0ec50827c745597c782ff46b571dbfe46192ab9e0b3c33", size = 595615, upload-time = "2025-10-14T15:05:32.074Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/0f/c6988c91d06e93cd0bb3d4a808bcf32375ca1904609835c3031799e3ecae/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:04e78dd0b6352db95507fd8cb46f39d185cf8c74e4cf1e4fbad1d3df96faf510", size = 474836, upload-time = "2025-10-14T15:05:33.209Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/36/ded8aebea91919485b7bbabbd14f5f359326cb5ec218cd67074d1e426d74/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5c85794a4cfa094714fb9c08d4a218375b2b95b8ed1666e8677c349906246c05", size = 455099, upload-time = "2025-10-14T15:05:34.189Z" },
+    { url = "https://files.pythonhosted.org/packages/98/e0/8c9bdba88af756a2fce230dd365fab2baf927ba42cd47521ee7498fd5211/watchfiles-1.1.1-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:74d5012b7630714b66be7b7b7a78855ef7ad58e8650c73afc4c076a1f480a8d6", size = 630626, upload-time = "2025-10-14T15:05:35.216Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/84/a95db05354bf2d19e438520d92a8ca475e578c647f78f53197f5a2f17aaf/watchfiles-1.1.1-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:8fbe85cb3201c7d380d3d0b90e63d520f15d6afe217165d7f98c9c649654db81", size = 622519, upload-time = "2025-10-14T15:05:36.259Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/ce/d8acdc8de545de995c339be67711e474c77d643555a9bb74a9334252bd55/watchfiles-1.1.1-cp314-cp314-win32.whl", hash = "sha256:3fa0b59c92278b5a7800d3ee7733da9d096d4aabcfabb9a928918bd276ef9b9b", size = 272078, upload-time = "2025-10-14T15:05:37.63Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/c9/a74487f72d0451524be827e8edec251da0cc1fcf111646a511ae752e1a3d/watchfiles-1.1.1-cp314-cp314-win_amd64.whl", hash = "sha256:c2047d0b6cea13b3316bdbafbfa0c4228ae593d995030fda39089d36e64fc03a", size = 287664, upload-time = "2025-10-14T15:05:38.95Z" },
+    { url = "https://files.pythonhosted.org/packages/df/b8/8ac000702cdd496cdce998c6f4ee0ca1f15977bba51bdf07d872ebdfc34c/watchfiles-1.1.1-cp314-cp314-win_arm64.whl", hash = "sha256:842178b126593addc05acf6fce960d28bc5fae7afbaa2c6c1b3a7b9460e5be02", size = 277154, upload-time = "2025-10-14T15:05:39.954Z" },
+    { url = "https://files.pythonhosted.org/packages/47/a8/e3af2184707c29f0f14b1963c0aace6529f9d1b8582d5b99f31bbf42f59e/watchfiles-1.1.1-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:88863fbbc1a7312972f1c511f202eb30866370ebb8493aef2812b9ff28156a21", size = 403820, upload-time = "2025-10-14T15:05:40.932Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/ec/e47e307c2f4bd75f9f9e8afbe3876679b18e1bcec449beca132a1c5ffb2d/watchfiles-1.1.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:55c7475190662e202c08c6c0f4d9e345a29367438cf8e8037f3155e10a88d5a5", size = 390510, upload-time = "2025-10-14T15:05:41.945Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/a0/ad235642118090f66e7b2f18fd5c42082418404a79205cdfca50b6309c13/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3f53fa183d53a1d7a8852277c92b967ae99c2d4dcee2bfacff8868e6e30b15f7", size = 448408, upload-time = "2025-10-14T15:05:43.385Z" },
+    { url = "https://files.pythonhosted.org/packages/df/85/97fa10fd5ff3332ae17e7e40e20784e419e28521549780869f1413742e9d/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6aae418a8b323732fa89721d86f39ec8f092fc2af67f4217a2b07fd3e93c6101", size = 458968, upload-time = "2025-10-14T15:05:44.404Z" },
+    { url = "https://files.pythonhosted.org/packages/47/c2/9059c2e8966ea5ce678166617a7f75ecba6164375f3b288e50a40dc6d489/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f096076119da54a6080e8920cbdaac3dbee667eb91dcc5e5b78840b87415bd44", size = 488096, upload-time = "2025-10-14T15:05:45.398Z" },
+    { url = "https://files.pythonhosted.org/packages/94/44/d90a9ec8ac309bc26db808a13e7bfc0e4e78b6fc051078a554e132e80160/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:00485f441d183717038ed2e887a7c868154f216877653121068107b227a2f64c", size = 596040, upload-time = "2025-10-14T15:05:46.502Z" },
+    { url = "https://files.pythonhosted.org/packages/95/68/4e3479b20ca305cfc561db3ed207a8a1c745ee32bf24f2026a129d0ddb6e/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a55f3e9e493158d7bfdb60a1165035f1cf7d320914e7b7ea83fe22c6023b58fc", size = 473847, upload-time = "2025-10-14T15:05:47.484Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/55/2af26693fd15165c4ff7857e38330e1b61ab8c37d15dc79118cdba115b7a/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8c91ed27800188c2ae96d16e3149f199d62f86c7af5f5f4d2c61a3ed8cd3666c", size = 455072, upload-time = "2025-10-14T15:05:48.928Z" },
+    { url = "https://files.pythonhosted.org/packages/66/1d/d0d200b10c9311ec25d2273f8aad8c3ef7cc7ea11808022501811208a750/watchfiles-1.1.1-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:311ff15a0bae3714ffb603e6ba6dbfba4065ab60865d15a6ec544133bdb21099", size = 629104, upload-time = "2025-10-14T15:05:49.908Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/bd/fa9bb053192491b3867ba07d2343d9f2252e00811567d30ae8d0f78136fe/watchfiles-1.1.1-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:a916a2932da8f8ab582f242c065f5c81bed3462849ca79ee357dd9551b0e9b01", size = 622112, upload-time = "2025-10-14T15:05:50.941Z" },
+]
+
+[[package]]
+name = "wcwidth"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/35/a2/8e3becb46433538a38726c948d3399905a4c7cabd0df578ede5dc51f0ec2/wcwidth-0.6.0.tar.gz", hash = "sha256:cdc4e4262d6ef9a1a57e018384cbeb1208d8abbc64176027e2c2455c81313159", size = 159684, upload-time = "2026-02-06T19:19:40.919Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/5a/199c59e0a824a3db2b89c5d2dade7ab5f9624dbf6448dc291b46d5ec94d3/wcwidth-0.6.0-py3-none-any.whl", hash = "sha256:1a3a1e510b553315f8e146c54764f4fb6264ffad731b3d78088cdb1478ffbdad", size = 94189, upload-time = "2026-02-06T19:19:39.646Z" },
+]
+
+[[package]]
+name = "websockets"
+version = "16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/04/24/4b2031d72e840ce4c1ccb255f693b15c334757fc50023e4db9537080b8c4/websockets-16.0.tar.gz", hash = "sha256:5f6261a5e56e8d5c42a4497b364ea24d94d9563e8fbd44e78ac40879c60179b5", size = 179346, upload-time = "2026-01-10T09:23:47.181Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/7b/bac442e6b96c9d25092695578dda82403c77936104b5682307bd4deb1ad4/websockets-16.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:71c989cbf3254fbd5e84d3bff31e4da39c43f884e64f2551d14bb3c186230f00", size = 177365, upload-time = "2026-01-10T09:22:46.787Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/fe/136ccece61bd690d9c1f715baaeefd953bb2360134de73519d5df19d29ca/websockets-16.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:8b6e209ffee39ff1b6d0fa7bfef6de950c60dfb91b8fcead17da4ee539121a79", size = 175038, upload-time = "2026-01-10T09:22:47.999Z" },
+    { url = "https://files.pythonhosted.org/packages/40/1e/9771421ac2286eaab95b8575b0cb701ae3663abf8b5e1f64f1fd90d0a673/websockets-16.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:86890e837d61574c92a97496d590968b23c2ef0aeb8a9bc9421d174cd378ae39", size = 175328, upload-time = "2026-01-10T09:22:49.809Z" },
+    { url = "https://files.pythonhosted.org/packages/18/29/71729b4671f21e1eaa5d6573031ab810ad2936c8175f03f97f3ff164c802/websockets-16.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9b5aca38b67492ef518a8ab76851862488a478602229112c4b0d58d63a7a4d5c", size = 184915, upload-time = "2026-01-10T09:22:51.071Z" },
+    { url = "https://files.pythonhosted.org/packages/97/bb/21c36b7dbbafc85d2d480cd65df02a1dc93bf76d97147605a8e27ff9409d/websockets-16.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e0334872c0a37b606418ac52f6ab9cfd17317ac26365f7f65e203e2d0d0d359f", size = 186152, upload-time = "2026-01-10T09:22:52.224Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/34/9bf8df0c0cf88fa7bfe36678dc7b02970c9a7d5e065a3099292db87b1be2/websockets-16.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a0b31e0b424cc6b5a04b8838bbaec1688834b2383256688cf47eb97412531da1", size = 185583, upload-time = "2026-01-10T09:22:53.443Z" },
+    { url = "https://files.pythonhosted.org/packages/47/88/4dd516068e1a3d6ab3c7c183288404cd424a9a02d585efbac226cb61ff2d/websockets-16.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:485c49116d0af10ac698623c513c1cc01c9446c058a4e61e3bf6c19dff7335a2", size = 184880, upload-time = "2026-01-10T09:22:55.033Z" },
+    { url = "https://files.pythonhosted.org/packages/91/d6/7d4553ad4bf1c0421e1ebd4b18de5d9098383b5caa1d937b63df8d04b565/websockets-16.0-cp312-cp312-win32.whl", hash = "sha256:eaded469f5e5b7294e2bdca0ab06becb6756ea86894a47806456089298813c89", size = 178261, upload-time = "2026-01-10T09:22:56.251Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/f0/f3a17365441ed1c27f850a80b2bc680a0fa9505d733fe152fdf5e98c1c0b/websockets-16.0-cp312-cp312-win_amd64.whl", hash = "sha256:5569417dc80977fc8c2d43a86f78e0a5a22fee17565d78621b6bb264a115d4ea", size = 178693, upload-time = "2026-01-10T09:22:57.478Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/9c/baa8456050d1c1b08dd0ec7346026668cbc6f145ab4e314d707bb845bf0d/websockets-16.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:878b336ac47938b474c8f982ac2f7266a540adc3fa4ad74ae96fea9823a02cc9", size = 177364, upload-time = "2026-01-10T09:22:59.333Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/0c/8811fc53e9bcff68fe7de2bcbe75116a8d959ac699a3200f4847a8925210/websockets-16.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:52a0fec0e6c8d9a784c2c78276a48a2bdf099e4ccc2a4cad53b27718dbfd0230", size = 175039, upload-time = "2026-01-10T09:23:01.171Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/82/39a5f910cb99ec0b59e482971238c845af9220d3ab9fa76dd9162cda9d62/websockets-16.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e6578ed5b6981005df1860a56e3617f14a6c307e6a71b4fff8c48fdc50f3ed2c", size = 175323, upload-time = "2026-01-10T09:23:02.341Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/28/0a25ee5342eb5d5f297d992a77e56892ecb65e7854c7898fb7d35e9b33bd/websockets-16.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:95724e638f0f9c350bb1c2b0a7ad0e83d9cc0c9259f3ea94e40d7b02a2179ae5", size = 184975, upload-time = "2026-01-10T09:23:03.756Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/66/27ea52741752f5107c2e41fda05e8395a682a1e11c4e592a809a90c6a506/websockets-16.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c0204dc62a89dc9d50d682412c10b3542d748260d743500a85c13cd1ee4bde82", size = 186203, upload-time = "2026-01-10T09:23:05.01Z" },
+    { url = "https://files.pythonhosted.org/packages/37/e5/8e32857371406a757816a2b471939d51c463509be73fa538216ea52b792a/websockets-16.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:52ac480f44d32970d66763115edea932f1c5b1312de36df06d6b219f6741eed8", size = 185653, upload-time = "2026-01-10T09:23:06.301Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/67/f926bac29882894669368dc73f4da900fcdf47955d0a0185d60103df5737/websockets-16.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6e5a82b677f8f6f59e8dfc34ec06ca6b5b48bc4fcda346acd093694cc2c24d8f", size = 184920, upload-time = "2026-01-10T09:23:07.492Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/a1/3d6ccdcd125b0a42a311bcd15a7f705d688f73b2a22d8cf1c0875d35d34a/websockets-16.0-cp313-cp313-win32.whl", hash = "sha256:abf050a199613f64c886ea10f38b47770a65154dc37181bfaff70c160f45315a", size = 178255, upload-time = "2026-01-10T09:23:09.245Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/ae/90366304d7c2ce80f9b826096a9e9048b4bb760e44d3b873bb272cba696b/websockets-16.0-cp313-cp313-win_amd64.whl", hash = "sha256:3425ac5cf448801335d6fdc7ae1eb22072055417a96cc6b31b3861f455fbc156", size = 178689, upload-time = "2026-01-10T09:23:10.483Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/1d/e88022630271f5bd349ed82417136281931e558d628dd52c4d8621b4a0b2/websockets-16.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8cc451a50f2aee53042ac52d2d053d08bf89bcb31ae799cb4487587661c038a0", size = 177406, upload-time = "2026-01-10T09:23:12.178Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/78/e63be1bf0724eeb4616efb1ae1c9044f7c3953b7957799abb5915bffd38e/websockets-16.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:daa3b6ff70a9241cf6c7fc9e949d41232d9d7d26fd3522b1ad2b4d62487e9904", size = 175085, upload-time = "2026-01-10T09:23:13.511Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/f4/d3c9220d818ee955ae390cf319a7c7a467beceb24f05ee7aaaa2414345ba/websockets-16.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:fd3cb4adb94a2a6e2b7c0d8d05cb94e6f1c81a0cf9dc2694fb65c7e8d94c42e4", size = 175328, upload-time = "2026-01-10T09:23:14.727Z" },
+    { url = "https://files.pythonhosted.org/packages/63/bc/d3e208028de777087e6fb2b122051a6ff7bbcca0d6df9d9c2bf1dd869ae9/websockets-16.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:781caf5e8eee67f663126490c2f96f40906594cb86b408a703630f95550a8c3e", size = 185044, upload-time = "2026-01-10T09:23:15.939Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/6e/9a0927ac24bd33a0a9af834d89e0abc7cfd8e13bed17a86407a66773cc0e/websockets-16.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:caab51a72c51973ca21fa8a18bd8165e1a0183f1ac7066a182ff27107b71e1a4", size = 186279, upload-time = "2026-01-10T09:23:17.148Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/ca/bf1c68440d7a868180e11be653c85959502efd3a709323230314fda6e0b3/websockets-16.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:19c4dc84098e523fd63711e563077d39e90ec6702aff4b5d9e344a60cb3c0cb1", size = 185711, upload-time = "2026-01-10T09:23:18.372Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/f8/fdc34643a989561f217bb477cbc47a3a07212cbda91c0e4389c43c296ebf/websockets-16.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:a5e18a238a2b2249c9a9235466b90e96ae4795672598a58772dd806edc7ac6d3", size = 184982, upload-time = "2026-01-10T09:23:19.652Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/d1/574fa27e233764dbac9c52730d63fcf2823b16f0856b3329fc6268d6ae4f/websockets-16.0-cp314-cp314-win32.whl", hash = "sha256:a069d734c4a043182729edd3e9f247c3b2a4035415a9172fd0f1b71658a320a8", size = 177915, upload-time = "2026-01-10T09:23:21.458Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/f1/ae6b937bf3126b5134ce1f482365fde31a357c784ac51852978768b5eff4/websockets-16.0-cp314-cp314-win_amd64.whl", hash = "sha256:c0ee0e63f23914732c6d7e0cce24915c48f3f1512ec1d079ed01fc629dab269d", size = 178381, upload-time = "2026-01-10T09:23:22.715Z" },
+    { url = "https://files.pythonhosted.org/packages/06/9b/f791d1db48403e1f0a27577a6beb37afae94254a8c6f08be4a23e4930bc0/websockets-16.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:a35539cacc3febb22b8f4d4a99cc79b104226a756aa7400adc722e83b0d03244", size = 177737, upload-time = "2026-01-10T09:23:24.523Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/40/53ad02341fa33b3ce489023f635367a4ac98b73570102ad2cdd770dacc9a/websockets-16.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:b784ca5de850f4ce93ec85d3269d24d4c82f22b7212023c974c401d4980ebc5e", size = 175268, upload-time = "2026-01-10T09:23:25.781Z" },
+    { url = "https://files.pythonhosted.org/packages/74/9b/6158d4e459b984f949dcbbb0c5d270154c7618e11c01029b9bbd1bb4c4f9/websockets-16.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:569d01a4e7fba956c5ae4fc988f0d4e187900f5497ce46339c996dbf24f17641", size = 175486, upload-time = "2026-01-10T09:23:27.033Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/2d/7583b30208b639c8090206f95073646c2c9ffd66f44df967981a64f849ad/websockets-16.0-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:50f23cdd8343b984957e4077839841146f67a3d31ab0d00e6b824e74c5b2f6e8", size = 185331, upload-time = "2026-01-10T09:23:28.259Z" },
+    { url = "https://files.pythonhosted.org/packages/45/b0/cce3784eb519b7b5ad680d14b9673a31ab8dcb7aad8b64d81709d2430aa8/websockets-16.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:152284a83a00c59b759697b7f9e9cddf4e3c7861dd0d964b472b70f78f89e80e", size = 186501, upload-time = "2026-01-10T09:23:29.449Z" },
+    { url = "https://files.pythonhosted.org/packages/19/60/b8ebe4c7e89fb5f6cdf080623c9d92789a53636950f7abacfc33fe2b3135/websockets-16.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bc59589ab64b0022385f429b94697348a6a234e8ce22544e3681b2e9331b5944", size = 186062, upload-time = "2026-01-10T09:23:31.368Z" },
+    { url = "https://files.pythonhosted.org/packages/88/a8/a080593f89b0138b6cba1b28f8df5673b5506f72879322288b031337c0b8/websockets-16.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:32da954ffa2814258030e5a57bc73a3635463238e797c7375dc8091327434206", size = 185356, upload-time = "2026-01-10T09:23:32.627Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/b6/b9afed2afadddaf5ebb2afa801abf4b0868f42f8539bfe4b071b5266c9fe/websockets-16.0-cp314-cp314t-win32.whl", hash = "sha256:5a4b4cc550cb665dd8a47f868c8d04c8230f857363ad3c9caf7a0c3bf8c61ca6", size = 178085, upload-time = "2026-01-10T09:23:33.816Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/3e/28135a24e384493fa804216b79a6a6759a38cc4ff59118787b9fb693df93/websockets-16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b14dc141ed6d2dde437cddb216004bcac6a1df0935d79656387bd41632ba0bbd", size = 178531, upload-time = "2026-01-10T09:23:35.016Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
+]


### PR DESCRIPTION
## Summary
Closes #17

- Add **ruff** linter and formatter with CI job (lint + format check)
- Add **mypy** static type checker with CI job
- Fix all existing lint and type errors across the codebase
- Add README badges: CI status, Python version, License, Ruff, mypy
- Add **Makefile** with `help`, `up`, `down`, `test`, `lint`, `format`, `typecheck`, `check`, `clean` targets
- CI now also triggers on push to `main` (required for status badge)

## Test plan
- [x] `ruff check .` passes
- [x] `ruff format --check .` passes
- [x] `mypy server/` passes
- [x] All 255 unit tests pass
- [x] CI pipeline passes with new lint and type-check jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)