### PR TITLE
feat: expanded view toggle and AI-generated session titles

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -415,6 +415,46 @@ body {
 .preview-role.assistant { background: rgba(124, 58, 237, 0.15); color: #c4b5fd; }
 .preview-role.tool_result { background: rgba(245, 158, 11, 0.15); color: #fcd34d; }
 
+/* Expanded view toggle */
+#expanded-view-btn.active {
+  background: var(--accent-muted);
+  border-color: var(--accent);
+  color: var(--accent-hover);
+}
+
+.card-expanded-preview {
+  margin: 6px 0 8px;
+  padding: 6px 8px;
+  background: var(--surface-2);
+  border-radius: var(--radius);
+  border-left: 2px solid var(--accent);
+  font-size: 11px;
+  max-height: 200px;
+  overflow-y: auto;
+}
+
+.card-expanded-preview .preview-msg {
+  padding: 3px 0;
+  color: var(--text-secondary);
+  line-height: 1.4;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.card-expanded-preview .preview-msg + .preview-msg {
+  border-top: 1px solid var(--border);
+}
+
+.card-expanded-preview .expanded-loading {
+  color: var(--text-muted);
+  font-style: italic;
+}
+
+.session-grid.expanded-view {
+  grid-template-columns: repeat(auto-fill, minmax(440px, 1fr));
+}
+
 .card-task {
   font-size: 12px;
   color: var(--text-secondary);

--- a/public/index.html
+++ b/public/index.html
@@ -26,6 +26,7 @@
         </div>
       </div>
       <div class="topbar-actions">
+        <button class="btn btn-sm" id="expanded-view-btn" title="Toggle expanded view">Expanded</button>
         <button class="btn btn-sm" id="settings-btn" title="Settings">&#9881; Settings</button>
       </div>
     </header>
@@ -92,6 +93,7 @@
         <div class="settings-body">
           <div class="settings-sidebar">
             <button class="settings-tab active" data-tab="integrations">&#128279; Integrations</button>
+            <button class="settings-tab" data-tab="summaries">&#9881; AI Summaries</button>
           </div>
           <div class="settings-content">
             <div class="settings-panel active" id="tab-integrations">
@@ -106,6 +108,16 @@
                   <label for="jira-url">Server URL</label>
                   <input type="text" class="input" id="jira-url" placeholder="https://company.atlassian.net" />
                   <small class="form-hint">Your Atlassian Cloud URL or self-hosted Jira base URL. Ticket IDs will link to <code>{url}/browse/PROJ-42</code>.</small>
+                </div>
+              </div>
+            </div>
+            <div class="settings-panel" id="tab-summaries">
+              <div class="settings-section">
+                <div class="section-title">AI Session Summaries</div>
+                <div class="form-group">
+                  <label for="summary-interval">Update title every N user messages</label>
+                  <input type="number" class="input" id="summary-interval" min="1" max="100" value="5" />
+                  <small class="form-hint">Runs <code>claude -p</code> in the background to generate an evolving session title. Set to a higher number to reduce frequency. Requires the <code>claude</code> CLI to be available.</small>
                 </div>
               </div>
             </div>

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -18,6 +18,7 @@ const App = {
     this.loadInitialData();
     this.loadSettings();
     this.setupHistory();
+    Dashboard.initExpandedView();
   },
 
   // ---- Browser History (back/forward) ----
@@ -105,6 +106,7 @@ const App = {
       const keys = this.settings.jira_project_keys || [];
       document.getElementById('jira-keys').value = keys.join(', ');
       document.getElementById('jira-url').value = this.settings.jira_server_url || '';
+      document.getElementById('summary-interval').value = this.settings.summary_interval || 5;
       indicator.textContent = '';
       indicator.className = 'save-indicator';
       modal.style.display = 'flex';
@@ -131,6 +133,7 @@ const App = {
       const keysRaw = document.getElementById('jira-keys').value;
       const keys = keysRaw.split(',').map(k => k.trim().toUpperCase()).filter(Boolean);
       const url = document.getElementById('jira-url').value.trim();
+      const summaryInterval = parseInt(document.getElementById('summary-interval').value, 10) || 5;
       try {
         const resp = await fetch('/api/settings', {
           method: 'PUT',
@@ -138,6 +141,7 @@ const App = {
           body: JSON.stringify({
             jira_project_keys: keys,
             jira_server_url: url || null,
+            summary_interval: summaryInterval,
           }),
         });
         const data = await resp.json();

--- a/public/js/dashboard.js
+++ b/public/js/dashboard.js
@@ -247,7 +247,7 @@ const Dashboard = {
       fetch(`/api/sessions/${sessionId}`, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ display_name: val.trim() || '', display_name_locked: true }),
+        body: JSON.stringify(val.trim() ? { display_name: val.trim(), display_name_locked: true } : { display_name: '' }),
       })
       .then(r => r.json())
       .then(data => {
@@ -400,7 +400,7 @@ const Dashboard = {
     this._expandedView = stored === 'true';
     const btn = document.getElementById('expanded-view-btn');
     if (btn) {
-      if (this._expandedView) btn.classList.add('active');
+      this._updateExpandedBtn(btn);
       btn.addEventListener('click', () => this.toggleExpandedView());
     }
     const grid = document.getElementById('session-grid');
@@ -411,10 +411,15 @@ const Dashboard = {
     this._expandedView = !this._expandedView;
     localStorage.setItem('cccc_expanded_view', String(this._expandedView));
     const btn = document.getElementById('expanded-view-btn');
-    if (btn) btn.classList.toggle('active', this._expandedView);
+    if (btn) this._updateExpandedBtn(btn);
     const grid = document.getElementById('session-grid');
     if (grid) grid.classList.toggle('expanded-view', this._expandedView);
     this.render(App.sessions);
+  },
+
+  _updateExpandedBtn(btn) {
+    btn.classList.toggle('active', this._expandedView);
+    btn.textContent = this._expandedView ? 'Compact' : 'Expanded';
   },
 
   _loadExpandedPreviews(sessions) {
@@ -435,7 +440,7 @@ const Dashboard = {
       container.innerHTML = msgs.map(t => {
         const roleLabel = t.role === 'user' ? 'U' : t.role === 'assistant' ? 'A' : 'T';
         const text = (t.content || '').substring(0, 200);
-        return `<div class="preview-msg"><span class="preview-role ${t.role}">${roleLabel}</span> ${this._escapeHTML(text)}</div>`;
+        return `<div class="preview-msg"><span class="preview-role ${this._escapeHTML(t.role)}">${roleLabel}</span> ${this._escapeHTML(text)}</div>`;
       }).join('');
     } catch (e) {
       container.innerHTML = '<div class="expanded-loading">Failed to load</div>';

--- a/public/js/dashboard.js
+++ b/public/js/dashboard.js
@@ -5,6 +5,7 @@
 const Dashboard = {
   _expandedSubagentSections: new Set(),
   _expandedSubagentTranscripts: new Set(),
+  _expandedView: false,
 
   _emptyHTML: `<div class="empty-state" id="empty-state">
       <div class="empty-icon">&#9678;</div>
@@ -30,6 +31,10 @@ const Dashboard = {
     list.forEach(session => {
       grid.appendChild(this.createCard(session));
     });
+
+    if (this._expandedView) {
+      this._loadExpandedPreviews(list);
+    }
   },
 
   createCard(session) {
@@ -61,6 +66,9 @@ const Dashboard = {
           this._loadSubagentTranscript(agentId, container);
         }
       });
+      if (this._expandedView) {
+        this._fetchExpandedPreview(session.id);
+      }
     } else {
       // New session — add card
       const grid = document.getElementById('session-grid');
@@ -68,6 +76,9 @@ const Dashboard = {
       if (empty) empty.remove();
       const card = this.createCard(session);
       grid.prepend(card);
+      if (this._expandedView) {
+        this._fetchExpandedPreview(session.id);
+      }
     }
 
     // Remove completed sessions from active view after a delay
@@ -125,14 +136,21 @@ const Dashboard = {
     const lockIcon = isLocked ? '&#128274;' : '&#128275;';
     const lockTitle = isLocked ? 'Title locked (click to unlock)' : 'Title auto-updates (click to lock)';
 
-    const previewText = s.last_activity_preview || '';
-    const previewLine = previewText
-      ? `<div class="card-preview" onclick="event.stopPropagation(); Dashboard.togglePreview('${this._escapeHTML(s.id)}', this)">
-          <span class="preview-chevron">&#9656;</span>
-          <span class="preview-text">${this._escapeHTML(previewText)}</span>
-        </div>
-        <div class="card-preview-expanded" id="preview-${s.id}" style="display:none"></div>`
-      : '';
+    let previewLine = '';
+    if (this._expandedView) {
+      previewLine = `<div class="card-expanded-preview" id="expanded-preview-${s.id}">
+        <div class="expanded-loading">Loading...</div>
+      </div>`;
+    } else {
+      const previewText = s.last_activity_preview || '';
+      previewLine = previewText
+        ? `<div class="card-preview" onclick="event.stopPropagation(); Dashboard.togglePreview('${this._escapeHTML(s.id)}', this)">
+            <span class="preview-chevron">&#9656;</span>
+            <span class="preview-text">${this._escapeHTML(previewText)}</span>
+          </div>
+          <div class="card-preview-expanded" id="preview-${s.id}" style="display:none"></div>`
+        : '';
+    }
 
     return `
       <div class="card-header">
@@ -229,7 +247,7 @@ const Dashboard = {
       fetch(`/api/sessions/${sessionId}`, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ display_name: val.trim() || '' }),
+        body: JSON.stringify({ display_name: val.trim() || '', display_name_locked: true }),
       })
       .then(r => r.json())
       .then(data => {
@@ -375,6 +393,53 @@ const Dashboard = {
     this._loadSubagentTranscript(agentId, container);
     container.style.display = 'block';
     if (chevron) chevron.style.transform = 'rotate(90deg)';
+  },
+
+  initExpandedView() {
+    const stored = localStorage.getItem('cccc_expanded_view');
+    this._expandedView = stored === 'true';
+    const btn = document.getElementById('expanded-view-btn');
+    if (btn) {
+      if (this._expandedView) btn.classList.add('active');
+      btn.addEventListener('click', () => this.toggleExpandedView());
+    }
+    const grid = document.getElementById('session-grid');
+    if (grid && this._expandedView) grid.classList.add('expanded-view');
+  },
+
+  toggleExpandedView() {
+    this._expandedView = !this._expandedView;
+    localStorage.setItem('cccc_expanded_view', String(this._expandedView));
+    const btn = document.getElementById('expanded-view-btn');
+    if (btn) btn.classList.toggle('active', this._expandedView);
+    const grid = document.getElementById('session-grid');
+    if (grid) grid.classList.toggle('expanded-view', this._expandedView);
+    this.render(App.sessions);
+  },
+
+  _loadExpandedPreviews(sessions) {
+    sessions.forEach(s => this._fetchExpandedPreview(s.id));
+  },
+
+  async _fetchExpandedPreview(sessionId) {
+    const container = document.getElementById(`expanded-preview-${sessionId}`);
+    if (!container) return;
+    try {
+      const resp = await fetch(`/api/sessions/${sessionId}/transcript?limit=5`);
+      const data = await resp.json();
+      const msgs = data.transcripts || [];
+      if (msgs.length === 0) {
+        container.innerHTML = '<div class="expanded-loading">No activity yet</div>';
+        return;
+      }
+      container.innerHTML = msgs.map(t => {
+        const roleLabel = t.role === 'user' ? 'U' : t.role === 'assistant' ? 'A' : 'T';
+        const text = (t.content || '').substring(0, 200);
+        return `<div class="preview-msg"><span class="preview-role ${t.role}">${roleLabel}</span> ${this._escapeHTML(text)}</div>`;
+      }).join('');
+    } catch (e) {
+      container.innerHTML = '<div class="expanded-loading">Failed to load</div>';
+    }
   },
 
   async _loadSubagentTranscript(agentId, container) {

--- a/server/db.py
+++ b/server/db.py
@@ -372,18 +372,22 @@ async def get_session_transcripts(
     return [dict(r) for r in rows]
 
 
-async def get_recent_user_messages(session_id: str, limit: int = 10) -> list[str]:
-    """Get the most recent user messages for a session, in chronological order."""
+async def get_recent_conversation(session_id: str, limit: int = 5) -> list[dict]:
+    """Get the most recent user+assistant messages for a session, in chronological order.
+
+    Skips tool_result entries so the result captures intent and decisions,
+    not noisy tool output.
+    """
     conn = await get_db()
     cursor = await conn.execute(
-        """SELECT content FROM transcripts
-           WHERE session_id = ? AND role = 'user'
+        """SELECT role, content FROM transcripts
+           WHERE session_id = ? AND role IN ('user', 'assistant')
            ORDER BY id DESC
            LIMIT ?""",
         (session_id, limit),
     )
     rows = await cursor.fetchall()
-    return [row["content"] for row in list(rows)[::-1]]
+    return [dict(r) for r in list(rows)[::-1]]
 
 
 async def search_transcripts(query: str, limit: int = 50) -> list[dict]:

--- a/server/db.py
+++ b/server/db.py
@@ -372,6 +372,20 @@ async def get_session_transcripts(
     return [dict(r) for r in rows]
 
 
+async def get_recent_user_messages(session_id: str, limit: int = 10) -> list[str]:
+    """Get the most recent user messages for a session, in chronological order."""
+    conn = await get_db()
+    cursor = await conn.execute(
+        """SELECT content FROM transcripts
+           WHERE session_id = ? AND role = 'user'
+           ORDER BY id DESC
+           LIMIT ?""",
+        (session_id, limit),
+    )
+    rows = await cursor.fetchall()
+    return [row["content"] for row in list(rows)[::-1]]
+
+
 async def search_transcripts(query: str, limit: int = 50) -> list[dict]:
     """Full-text search across transcripts."""
     db = await get_db()

--- a/server/routes/api.py
+++ b/server/routes/api.py
@@ -40,6 +40,7 @@ class NewSessionRequest(BaseModel):
 class SettingsUpdate(BaseModel):
     jira_project_keys: list[str] | None = None
     jira_server_url: str | None = None
+    summary_interval: int | None = None
 
 
 _UNSET = object()
@@ -158,6 +159,8 @@ async def update_settings(req: SettingsUpdate):
         await db.set_setting("jira_project_keys", json.dumps(req.jira_project_keys))
     if req.jira_server_url is not None:
         await db.set_setting("jira_server_url", json.dumps(req.jira_server_url))
+    if req.summary_interval is not None:
+        await db.set_setting("summary_interval", json.dumps(req.summary_interval))
     return await get_settings()
 
 

--- a/server/routes/api.py
+++ b/server/routes/api.py
@@ -160,6 +160,8 @@ async def update_settings(req: SettingsUpdate):
     if req.jira_server_url is not None:
         await db.set_setting("jira_server_url", json.dumps(req.jira_server_url))
     if req.summary_interval is not None:
+        if req.summary_interval < 1:
+            raise HTTPException(status_code=400, detail="summary_interval must be >= 1")
         await db.set_setting("summary_interval", json.dumps(req.summary_interval))
     return await get_settings()
 

--- a/server/watcher.py
+++ b/server/watcher.py
@@ -497,16 +497,34 @@ def _parse_summary_response(raw: str) -> dict | None:
     if not isinstance(title, str) or not title or len(title) > 100:
         return None
 
+    # Validate pr_url: must be https with a PR/MR path shape
+    pr_url = data.get("pr_url") if isinstance(data.get("pr_url"), str) else None
+    if pr_url and not re.match(r"^https://[^/]+/.+/(?:pull|merge_requests)/\d+", pr_url):
+        pr_url = None
+
     return {
         "title": title.strip(),
         "ticket_id": data.get("ticket_id") if isinstance(data.get("ticket_id"), str) else None,
-        "pr_url": data.get("pr_url") if isinstance(data.get("pr_url"), str) else None,
+        "pr_url": pr_url,
     }
+
+
+async def _kill_subprocess(proc: asyncio.subprocess.Process) -> None:
+    """Terminate a subprocess and wait for it to be reaped."""
+    try:
+        proc.kill()
+    except (ProcessLookupError, OSError):
+        pass  # Already exited
+    try:
+        await proc.wait()
+    except Exception:
+        pass
 
 
 async def _generate_ai_summary(session_id: str) -> None:
     """Run claude -p to generate updated session metadata (title, ticket, PR)."""
     global _claude_available
+    proc: asyncio.subprocess.Process | None = None
     try:
         session = await db.get_session(session_id)
         if not session or session.get("display_name_locked"):
@@ -572,11 +590,15 @@ async def _generate_ai_summary(session_id: str) -> None:
 
     except TimeoutError:
         logger.warning("claude -p timed out for session %s", session_id)
+        if proc and proc.returncode is None:
+            await _kill_subprocess(proc)
     except FileNotFoundError:
         logger.warning("claude command not found — AI summaries disabled")
         _claude_available = False
     except Exception:
         logger.exception("Failed to generate AI summary for session %s", session_id)
+        if proc and proc.returncode is None:
+            await _kill_subprocess(proc)
     finally:
         _summary_tasks.pop(session_id, None)
 

--- a/server/watcher.py
+++ b/server/watcher.py
@@ -40,6 +40,13 @@ DEBOUNCE_SECONDS = 1.0
 
 _watcher_task: asyncio.Task | None = None
 
+# AI summary generation state
+_user_message_counts: dict[str, int] = {}
+_summary_tasks: dict[str, asyncio.Task] = {}
+_claude_available: bool = True
+SUMMARY_TRIGGER_INTERVAL = 5
+SUMMARY_SUBPROCESS_TIMEOUT = 90
+
 
 def _parse_jsonl_entry(line: str) -> dict | None:
     """Parse a single JSONL line into a structured entry.
@@ -385,6 +392,113 @@ async def _extract_ticket_id(branch_name: str) -> str | None:
     return None
 
 
+async def _get_summary_interval() -> int:
+    """Read the summary interval from settings, falling back to the default."""
+    raw = await db.get_setting("summary_interval")
+    if raw:
+        try:
+            val = json.loads(raw)
+            if isinstance(val, int) and val > 0:
+                return val
+        except (json.JSONDecodeError, TypeError):
+            pass
+    return SUMMARY_TRIGGER_INTERVAL
+
+
+async def _should_generate_summary(session_id: str, session: dict | None) -> bool:
+    """Check whether we should trigger an AI summary for this session."""
+    if not _claude_available:
+        return False
+    if not session:
+        return False
+    if session.get("display_name_locked"):
+        return False
+    if session.get("status") in ("completed", "stale"):
+        return False
+    if session.get("parent_session_id"):
+        return False
+    if session_id in _summary_tasks and not _summary_tasks[session_id].done():
+        return False
+    count = _user_message_counts.get(session_id, 0)
+    if count == 0:
+        return False
+    interval = await _get_summary_interval()
+    return count % interval == 0
+
+
+async def _generate_ai_summary(session_id: str) -> None:
+    """Run claude -p to generate an updated session title."""
+    global _claude_available
+    try:
+        session = await db.get_session(session_id)
+        if not session or session.get("display_name_locked"):
+            return
+
+        user_messages = await db.get_recent_user_messages(session_id, limit=SUMMARY_TRIGGER_INTERVAL)
+        if not user_messages:
+            return
+
+        git_branch = session.get("git_branch", "unknown")
+        current_title = session.get("display_name") or session.get("project_name") or ""
+
+        prompt = (
+            "You are a concise title generator for a coding session. "
+            "Based on the following context, generate a short title (3-8 words) "
+            "that captures what the developer is currently working on. "
+            "Return ONLY the title text, nothing else. No quotes, no explanation.\n\n"
+            f"Current title: {current_title}\n"
+            f"Git branch: {git_branch}\n"
+            f"Recent user messages:\n"
+        )
+        for i, msg in enumerate(user_messages, 1):
+            truncated = (msg or "")[:200]
+            prompt += f"{i}. {truncated}\n"
+
+        proc = await asyncio.create_subprocess_exec(
+            "claude",
+            "-p",
+            prompt,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=SUMMARY_SUBPROCESS_TIMEOUT)
+
+        if proc.returncode != 0:
+            logger.warning("claude -p failed for session %s: %s", session_id, stderr.decode()[:200])
+            return
+
+        new_title = stdout.decode().strip()
+
+        # Validate: non-empty, reasonable length, single line
+        if not new_title or len(new_title) > 100 or "\n" in new_title:
+            logger.warning("claude -p returned invalid title for %s: %r", session_id, new_title[:100])
+            return
+
+        # Re-check lock status (may have changed while subprocess ran)
+        session = await db.get_session(session_id)
+        if not session or session.get("display_name_locked"):
+            return
+
+        await db.update_session(session_id, display_name=new_title)
+
+        from server.routes.ws import broadcast_session_update
+
+        updated = await db.get_session(session_id)
+        if updated:
+            await broadcast_session_update(updated)
+        logger.info("AI summary updated title for %s: %s", session_id, new_title)
+
+    except TimeoutError:
+        logger.warning("claude -p timed out for session %s", session_id)
+    except FileNotFoundError:
+        logger.warning("claude command not found — AI summaries disabled")
+        _claude_available = False
+    except Exception:
+        logger.exception("Failed to generate AI summary for session %s", session_id)
+    finally:
+        _summary_tasks.pop(session_id, None)
+
+
 async def _process_file_changes(file_path: str):
     """Read new lines from a JSONL file and store as transcripts.
 
@@ -578,6 +692,19 @@ async def _process_file_changes(file_path: str):
         except Exception:
             pass  # Non-critical
 
+    # Count user messages for AI summary trigger
+    new_user_count = sum(1 for e in parsed_entries if e["role"] == "user")
+    if new_user_count > 0:
+        old_count = _user_message_counts.get(session_id, 0)
+        _user_message_counts[session_id] = old_count + new_user_count
+        new_total = _user_message_counts[session_id]
+        # Check if we crossed a summary threshold
+        interval = await _get_summary_interval()
+        if (old_count // interval) < (new_total // interval):
+            session_check = await db.get_session(session_id)
+            if await _should_generate_summary(session_id, session_check):
+                _summary_tasks[session_id] = asyncio.create_task(_generate_ai_summary(session_id))
+
 
 async def _debounced_process(file_path: str):
     """Debounce file processing to avoid excessive reads."""
@@ -637,3 +764,9 @@ def stop_watcher():
         if not task.done():
             task.cancel()
     _debounce_tasks.clear()
+    # Cancel in-flight summary tasks
+    for task in _summary_tasks.values():
+        if not task.done():
+            task.cancel()
+    _summary_tasks.clear()
+    _user_message_counts.clear()

--- a/server/watcher.py
+++ b/server/watcher.py
@@ -426,33 +426,97 @@ async def _should_generate_summary(session_id: str, session: dict | None) -> boo
     return count % interval == 0
 
 
+def _build_summary_prompt(session: dict, conversation: list[dict]) -> str:
+    """Build a structured prompt for session metadata extraction."""
+    current_title = session.get("display_name") or session.get("project_name") or "Untitled"
+    git_branch = session.get("git_branch") or "unknown"
+    current_ticket = session.get("ticket_id") or "none"
+    current_pr = session.get("pr_url") or "none"
+
+    lines = [
+        "You are a session metadata extractor for a coding dashboard.",
+        "",
+        "## Current Session State",
+        f"- Title: {current_title}",
+        f"- Git branch: {git_branch}",
+        f"- Ticket ID: {current_ticket}",
+        f"- PR URL: {current_pr}",
+        "",
+        "## Recent Activity",
+    ]
+
+    role_labels = {"user": "user", "assistant": "assistant"}
+    for i, msg in enumerate(conversation, 1):
+        role = role_labels.get(msg["role"], msg["role"])
+        content = (msg.get("content") or "")[:200]
+        lines.append(f"{i}. [{role}] {content}")
+
+    lines.extend(
+        [
+            "",
+            "## Task",
+            "Analyze the activity and return updated session metadata as JSON.",
+            "",
+            "## Output Schema",
+            "{",
+            '  "title": "3-8 word summary of current work",',
+            '  "ticket_id": "JIRA ticket ID (e.g. PROJ-42) or null if not found",',
+            '  "pr_url": "full PR/MR URL or null if not found"',
+            "}",
+            "",
+            "## Rules",
+            "- title: Always provide. Describe what the developer is working on right now.",
+            "- ticket_id: Extract only if explicitly mentioned in conversation. null otherwise.",
+            "- pr_url: Extract only if a full URL appears in conversation. null otherwise.",
+            "- Return ONLY valid JSON. No markdown fences, no explanation.",
+        ]
+    )
+
+    return "\n".join(lines)
+
+
+def _parse_summary_response(raw: str) -> dict | None:
+    """Parse the JSON response from claude -p, stripping markdown fences if present."""
+    text = raw.strip()
+    # Strip markdown code fences if the model wrapped its response
+    if text.startswith("```"):
+        # Remove opening fence (```json or ```)
+        text = text.split("\n", 1)[1] if "\n" in text else text[3:]
+    if text.endswith("```"):
+        text = text[:-3].rstrip()
+
+    try:
+        data = json.loads(text)
+    except (json.JSONDecodeError, ValueError):
+        return None
+
+    if not isinstance(data, dict):
+        return None
+
+    title = data.get("title")
+    if not isinstance(title, str) or not title or len(title) > 100:
+        return None
+
+    return {
+        "title": title.strip(),
+        "ticket_id": data.get("ticket_id") if isinstance(data.get("ticket_id"), str) else None,
+        "pr_url": data.get("pr_url") if isinstance(data.get("pr_url"), str) else None,
+    }
+
+
 async def _generate_ai_summary(session_id: str) -> None:
-    """Run claude -p to generate an updated session title."""
+    """Run claude -p to generate updated session metadata (title, ticket, PR)."""
     global _claude_available
     try:
         session = await db.get_session(session_id)
         if not session or session.get("display_name_locked"):
             return
 
-        user_messages = await db.get_recent_user_messages(session_id, limit=SUMMARY_TRIGGER_INTERVAL)
-        if not user_messages:
+        conversation = await db.get_recent_conversation(session_id, limit=5)
+        if not conversation:
             return
 
-        git_branch = session.get("git_branch", "unknown")
-        current_title = session.get("display_name") or session.get("project_name") or ""
-
-        prompt = (
-            "You are a concise title generator for a coding session. "
-            "Based on the following context, generate a short title (3-8 words) "
-            "that captures what the developer is currently working on. "
-            "Return ONLY the title text, nothing else. No quotes, no explanation.\n\n"
-            f"Current title: {current_title}\n"
-            f"Git branch: {git_branch}\n"
-            f"Recent user messages:\n"
-        )
-        for i, msg in enumerate(user_messages, 1):
-            truncated = (msg or "")[:200]
-            prompt += f"{i}. {truncated}\n"
+        prompt = _build_summary_prompt(session, conversation)
 
         proc = await asyncio.create_subprocess_exec(
             "claude",
@@ -467,11 +531,13 @@ async def _generate_ai_summary(session_id: str) -> None:
             logger.warning("claude -p failed for session %s: %s", session_id, stderr.decode()[:200])
             return
 
-        new_title = stdout.decode().strip()
-
-        # Validate: non-empty, reasonable length, single line
-        if not new_title or len(new_title) > 100 or "\n" in new_title:
-            logger.warning("claude -p returned invalid title for %s: %r", session_id, new_title[:100])
+        parsed = _parse_summary_response(stdout.decode())
+        if not parsed:
+            logger.warning(
+                "claude -p returned invalid response for %s: %r",
+                session_id,
+                stdout.decode()[:200],
+            )
             return
 
         # Re-check lock status (may have changed while subprocess ran)
@@ -479,14 +545,27 @@ async def _generate_ai_summary(session_id: str) -> None:
         if not session or session.get("display_name_locked"):
             return
 
-        await db.update_session(session_id, display_name=new_title)
+        updates: dict = {"display_name": parsed["title"]}
+        # Only fill in ticket_id and pr_url if not already set
+        if parsed["ticket_id"] and not session.get("ticket_id"):
+            updates["ticket_id"] = parsed["ticket_id"]
+        if parsed["pr_url"] and not session.get("pr_url"):
+            updates["pr_url"] = parsed["pr_url"]
+
+        await db.update_session(session_id, **updates)
 
         from server.routes.ws import broadcast_session_update
 
         updated = await db.get_session(session_id)
         if updated:
             await broadcast_session_update(updated)
-        logger.info("AI summary updated title for %s: %s", session_id, new_title)
+        logger.info(
+            "AI summary for %s: title=%r ticket=%s pr=%s",
+            session_id,
+            parsed["title"],
+            parsed["ticket_id"] or "-",
+            parsed["pr_url"] or "-",
+        )
 
     except TimeoutError:
         logger.warning("claude -p timed out for session %s", session_id)

--- a/server/watcher.py
+++ b/server/watcher.py
@@ -478,9 +478,9 @@ def _build_summary_prompt(session: dict, conversation: list[dict]) -> str:
 def _parse_summary_response(raw: str) -> dict | None:
     """Parse the JSON response from claude -p, stripping markdown fences if present."""
     text = raw.strip()
-    # Strip markdown code fences if the model wrapped its response
-    if text.startswith("```"):
-        # Remove opening fence (```json or ```)
+    # Strip markdown code fences if the model wrapped its response (case-insensitive)
+    if text.lower().startswith("```"):
+        # Remove opening fence (```json, ```JSON, ```)
         text = text.split("\n", 1)[1] if "\n" in text else text[3:]
     if text.endswith("```"):
         text = text[:-3].rstrip()
@@ -521,11 +521,14 @@ async def _generate_ai_summary(session_id: str) -> None:
         proc = await asyncio.create_subprocess_exec(
             "claude",
             "-p",
-            prompt,
+            "-",
+            stdin=asyncio.subprocess.PIPE,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
         )
-        stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=SUMMARY_SUBPROCESS_TIMEOUT)
+        stdout, stderr = await asyncio.wait_for(
+            proc.communicate(input=prompt.encode()), timeout=SUMMARY_SUBPROCESS_TIMEOUT
+        )
 
         if proc.returncode != 0:
             logger.warning("claude -p failed for session %s: %s", session_id, stderr.decode()[:200])

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -198,6 +198,16 @@ async def test_update_settings(client: AsyncClient):
     assert settings["jira_server_url"] == "https://jira.example.com"
 
 
+async def test_update_settings_summary_interval(client: AsyncClient):
+    resp = await client.put(
+        "/api/settings",
+        json={"summary_interval": 10},
+    )
+    assert resp.status_code == 200
+    settings = resp.json()["settings"]
+    assert settings["summary_interval"] == 10
+
+
 async def test_get_settings_with_values(client: AsyncClient):
     await db.set_setting("jira_project_keys", '["PROJ"]')
     await db.set_setting("plain_key", "not-json")

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -208,6 +208,22 @@ async def test_update_settings_summary_interval(client: AsyncClient):
     assert settings["summary_interval"] == 10
 
 
+async def test_update_settings_summary_interval_invalid(client: AsyncClient):
+    resp = await client.put(
+        "/api/settings",
+        json={"summary_interval": 0},
+    )
+    assert resp.status_code == 400
+
+
+async def test_update_settings_summary_interval_negative(client: AsyncClient):
+    resp = await client.put(
+        "/api/settings",
+        json={"summary_interval": -5},
+    )
+    assert resp.status_code == 400
+
+
 async def test_get_settings_with_values(client: AsyncClient):
     await db.set_setting("jira_project_keys", '["PROJ"]')
     await db.set_setting("plain_key", "not-json")

--- a/tests/unit/test_db.py
+++ b/tests/unit/test_db.py
@@ -288,3 +288,53 @@ async def test_active_sessions_exclude_subagents():
     ids = [s["id"] for s in active]
     assert "active-parent" in ids
     assert "active-child" not in ids
+
+
+async def test_get_recent_conversation():
+    """get_recent_conversation returns user+assistant messages in chronological order."""
+    await db.create_session("conv-1")
+    await db.add_transcript("conv-1", "user", "Hello")
+    await db.add_transcript("conv-1", "assistant", "Hi there")
+    await db.add_transcript("conv-1", "tool_result", "File contents...")
+    await db.add_transcript("conv-1", "user", "Fix the bug")
+    await db.add_transcript("conv-1", "assistant", "I will fix it")
+
+    msgs = await db.get_recent_conversation("conv-1", limit=5)
+    assert len(msgs) == 4
+    assert msgs[0]["role"] == "user"
+    assert msgs[0]["content"] == "Hello"
+    assert msgs[3]["role"] == "assistant"
+    assert msgs[3]["content"] == "I will fix it"
+    # tool_result should be excluded
+    assert all(m["role"] in ("user", "assistant") for m in msgs)
+
+
+async def test_get_recent_conversation_limit():
+    """get_recent_conversation respects the limit parameter."""
+    await db.create_session("conv-2")
+    for i in range(10):
+        await db.add_transcript("conv-2", "user", f"Message {i}")
+        await db.add_transcript("conv-2", "assistant", f"Reply {i}")
+
+    msgs = await db.get_recent_conversation("conv-2", limit=3)
+    assert len(msgs) == 3
+    # Should be the 3 most recent, in chronological order
+    assert msgs[0]["content"] == "Reply 8"
+    assert msgs[1]["content"] == "Message 9"
+    assert msgs[2]["content"] == "Reply 9"
+
+
+async def test_get_recent_conversation_empty():
+    """get_recent_conversation returns empty list for no messages."""
+    await db.create_session("conv-3")
+    msgs = await db.get_recent_conversation("conv-3")
+    assert msgs == []
+
+
+async def test_get_recent_conversation_only_tool_results():
+    """get_recent_conversation returns empty if only tool_result messages exist."""
+    await db.create_session("conv-4")
+    await db.add_transcript("conv-4", "tool_result", "some output")
+    await db.add_transcript("conv-4", "tool_result", "more output")
+    msgs = await db.get_recent_conversation("conv-4")
+    assert msgs == []

--- a/tests/unit/test_watcher.py
+++ b/tests/unit/test_watcher.py
@@ -1464,6 +1464,15 @@ def test_parse_summary_response_strips_plain_fences():
     assert result["title"] == "Debug Login"
 
 
+def test_parse_summary_response_strips_uppercase_json_fence():
+    from server.watcher import _parse_summary_response
+
+    raw = '```JSON\n{"title": "Uppercase Fence", "ticket_id": null, "pr_url": null}\n```'
+    result = _parse_summary_response(raw)
+    assert result is not None
+    assert result["title"] == "Uppercase Fence"
+
+
 def test_parse_summary_response_invalid_json():
     from server.watcher import _parse_summary_response
 

--- a/tests/unit/test_watcher.py
+++ b/tests/unit/test_watcher.py
@@ -1525,6 +1525,116 @@ def test_parse_summary_response_whitespace_title():
     assert result["title"] == "Fix Auth"
 
 
+def test_parse_summary_response_valid_github_pr_url():
+    from server.watcher import _parse_summary_response
+
+    raw = json.dumps({"title": "Test", "ticket_id": None, "pr_url": "https://github.com/org/repo/pull/42"})
+    result = _parse_summary_response(raw)
+    assert result["pr_url"] == "https://github.com/org/repo/pull/42"
+
+
+def test_parse_summary_response_valid_gitlab_mr_url():
+    from server.watcher import _parse_summary_response
+
+    raw = json.dumps({"title": "Test", "ticket_id": None, "pr_url": "https://gitlab.com/org/repo/-/merge_requests/7"})
+    result = _parse_summary_response(raw)
+    assert result["pr_url"] == "https://gitlab.com/org/repo/-/merge_requests/7"
+
+
+def test_parse_summary_response_rejects_javascript_url():
+    from server.watcher import _parse_summary_response
+
+    raw = json.dumps({"title": "Test", "ticket_id": None, "pr_url": "javascript:alert(1)"})
+    result = _parse_summary_response(raw)
+    assert result["pr_url"] is None
+
+
+def test_parse_summary_response_rejects_http_url():
+    from server.watcher import _parse_summary_response
+
+    raw = json.dumps({"title": "Test", "ticket_id": None, "pr_url": "http://github.com/org/repo/pull/1"})
+    result = _parse_summary_response(raw)
+    assert result["pr_url"] is None
+
+
+def test_parse_summary_response_rejects_arbitrary_https_url():
+    from server.watcher import _parse_summary_response
+
+    raw = json.dumps({"title": "Test", "ticket_id": None, "pr_url": "https://evil.com/phish"})
+    result = _parse_summary_response(raw)
+    assert result["pr_url"] is None
+
+
+def test_parse_summary_response_rejects_non_pr_path():
+    from server.watcher import _parse_summary_response
+
+    raw = json.dumps({"title": "Test", "ticket_id": None, "pr_url": "https://github.com/org/repo/issues/5"})
+    result = _parse_summary_response(raw)
+    assert result["pr_url"] is None
+
+
+# --- AI Summary: subprocess reaping ---
+
+
+async def test_generate_ai_summary_kills_subprocess_on_timeout():
+    from server.watcher import _generate_ai_summary
+
+    await db.create_session("reap-1", project_path="/tmp/proj")
+    await db.update_session("reap-1", status="working")
+    await db.add_transcript("reap-1", "user", "Do something")
+
+    mock_proc = AsyncMock()
+    mock_proc.returncode = None  # Still running
+
+    with (
+        patch("asyncio.create_subprocess_exec", new_callable=AsyncMock, return_value=mock_proc),
+        patch("asyncio.wait_for", new_callable=AsyncMock, side_effect=TimeoutError),
+    ):
+        await _generate_ai_summary("reap-1")
+
+    mock_proc.kill.assert_called_once()
+    mock_proc.wait.assert_called_once()
+
+
+async def test_generate_ai_summary_kills_subprocess_on_exception():
+    from server.watcher import _generate_ai_summary
+
+    await db.create_session("reap-2", project_path="/tmp/proj")
+    await db.update_session("reap-2", status="working")
+    await db.add_transcript("reap-2", "user", "Do something")
+
+    mock_proc = AsyncMock()
+    mock_proc.returncode = None
+
+    with (
+        patch("asyncio.create_subprocess_exec", new_callable=AsyncMock, return_value=mock_proc),
+        patch("asyncio.wait_for", new_callable=AsyncMock, side_effect=RuntimeError("boom")),
+    ):
+        await _generate_ai_summary("reap-2")
+
+    mock_proc.kill.assert_called_once()
+
+
+async def test_generate_ai_summary_skips_kill_if_already_exited():
+    from server.watcher import _generate_ai_summary
+
+    await db.create_session("reap-3", project_path="/tmp/proj")
+    await db.update_session("reap-3", status="working")
+    await db.add_transcript("reap-3", "user", "Do something")
+
+    mock_proc = AsyncMock()
+    mock_proc.returncode = 0  # Already exited
+
+    with (
+        patch("asyncio.create_subprocess_exec", new_callable=AsyncMock, return_value=mock_proc),
+        patch("asyncio.wait_for", new_callable=AsyncMock, side_effect=TimeoutError),
+    ):
+        await _generate_ai_summary("reap-3")
+
+    # returncode is not None, so kill should not be called
+    mock_proc.kill.assert_not_called()
+
+
 # --- AI Summary: _get_summary_interval ---
 
 

--- a/tests/unit/test_watcher.py
+++ b/tests/unit/test_watcher.py
@@ -1361,3 +1361,649 @@ async def test_process_file_fixes_orphaned_subagent():
         import shutil
 
         shutil.rmtree(parent_dir)
+
+
+# --- AI Summary: _build_summary_prompt ---
+
+
+def test_build_summary_prompt_basic():
+    from server.watcher import _build_summary_prompt
+
+    session = {
+        "display_name": "Auth Refactor",
+        "project_name": "myproject",
+        "git_branch": "feat/auth",
+        "ticket_id": "PROJ-42",
+        "pr_url": "https://github.com/org/repo/pull/7",
+    }
+    conversation = [
+        {"role": "user", "content": "Fix the auth middleware"},
+        {"role": "assistant", "content": "I will update the JWT handling"},
+    ]
+    prompt = _build_summary_prompt(session, conversation)
+    assert "Auth Refactor" in prompt
+    assert "feat/auth" in prompt
+    assert "PROJ-42" in prompt
+    assert "https://github.com/org/repo/pull/7" in prompt
+    assert "[user] Fix the auth middleware" in prompt
+    assert "[assistant] I will update the JWT handling" in prompt
+    assert '"title"' in prompt
+    assert '"ticket_id"' in prompt
+    assert '"pr_url"' in prompt
+
+
+def test_build_summary_prompt_missing_fields():
+    from server.watcher import _build_summary_prompt
+
+    session = {
+        "display_name": None,
+        "project_name": None,
+        "git_branch": None,
+        "ticket_id": None,
+        "pr_url": None,
+    }
+    prompt = _build_summary_prompt(session, [])
+    assert "Untitled" in prompt
+    assert "unknown" in prompt
+    assert "Ticket ID: none" in prompt
+    assert "PR URL: none" in prompt
+
+
+def test_build_summary_prompt_truncates_long_content():
+    from server.watcher import _build_summary_prompt
+
+    session = {"display_name": "Test", "git_branch": "main"}
+    long_msg = "x" * 500
+    conversation = [{"role": "user", "content": long_msg}]
+    prompt = _build_summary_prompt(session, conversation)
+    # Content should be truncated to 200 chars
+    assert "x" * 200 in prompt
+    assert "x" * 201 not in prompt
+
+
+# --- AI Summary: _parse_summary_response ---
+
+
+def test_parse_summary_response_valid():
+    from server.watcher import _parse_summary_response
+
+    raw = '{"title": "Fix Auth Bug", "ticket_id": "PROJ-42", "pr_url": "https://github.com/o/r/pull/1"}'
+    result = _parse_summary_response(raw)
+    assert result is not None
+    assert result["title"] == "Fix Auth Bug"
+    assert result["ticket_id"] == "PROJ-42"
+    assert result["pr_url"] == "https://github.com/o/r/pull/1"
+
+
+def test_parse_summary_response_nulls():
+    from server.watcher import _parse_summary_response
+
+    raw = '{"title": "Working on tests", "ticket_id": null, "pr_url": null}'
+    result = _parse_summary_response(raw)
+    assert result is not None
+    assert result["title"] == "Working on tests"
+    assert result["ticket_id"] is None
+    assert result["pr_url"] is None
+
+
+def test_parse_summary_response_strips_markdown_fences():
+    from server.watcher import _parse_summary_response
+
+    raw = '```json\n{"title": "Auth Refactor", "ticket_id": null, "pr_url": null}\n```'
+    result = _parse_summary_response(raw)
+    assert result is not None
+    assert result["title"] == "Auth Refactor"
+
+
+def test_parse_summary_response_strips_plain_fences():
+    from server.watcher import _parse_summary_response
+
+    raw = '```\n{"title": "Debug Login", "ticket_id": null, "pr_url": null}\n```'
+    result = _parse_summary_response(raw)
+    assert result is not None
+    assert result["title"] == "Debug Login"
+
+
+def test_parse_summary_response_invalid_json():
+    from server.watcher import _parse_summary_response
+
+    assert _parse_summary_response("not json at all") is None
+
+
+def test_parse_summary_response_missing_title():
+    from server.watcher import _parse_summary_response
+
+    assert _parse_summary_response('{"ticket_id": "X-1"}') is None
+
+
+def test_parse_summary_response_empty_title():
+    from server.watcher import _parse_summary_response
+
+    assert _parse_summary_response('{"title": "", "ticket_id": null, "pr_url": null}') is None
+
+
+def test_parse_summary_response_title_too_long():
+    from server.watcher import _parse_summary_response
+
+    long_title = "x" * 101
+    raw = json.dumps({"title": long_title, "ticket_id": None, "pr_url": None})
+    assert _parse_summary_response(raw) is None
+
+
+def test_parse_summary_response_non_dict():
+    from server.watcher import _parse_summary_response
+
+    assert _parse_summary_response("[1, 2, 3]") is None
+
+
+def test_parse_summary_response_non_string_ticket():
+    from server.watcher import _parse_summary_response
+
+    raw = '{"title": "Test", "ticket_id": 42, "pr_url": true}'
+    result = _parse_summary_response(raw)
+    assert result is not None
+    assert result["title"] == "Test"
+    assert result["ticket_id"] is None
+    assert result["pr_url"] is None
+
+
+def test_parse_summary_response_whitespace_title():
+    from server.watcher import _parse_summary_response
+
+    raw = '{"title": "  Fix Auth  ", "ticket_id": null, "pr_url": null}'
+    result = _parse_summary_response(raw)
+    assert result is not None
+    assert result["title"] == "Fix Auth"
+
+
+# --- AI Summary: _get_summary_interval ---
+
+
+async def test_get_summary_interval_default():
+    from server.watcher import SUMMARY_TRIGGER_INTERVAL, _get_summary_interval
+
+    result = await _get_summary_interval()
+    assert result == SUMMARY_TRIGGER_INTERVAL
+
+
+async def test_get_summary_interval_from_settings():
+    from server.watcher import _get_summary_interval
+
+    await db.set_setting("summary_interval", "10")
+    result = await _get_summary_interval()
+    assert result == 10
+
+
+async def test_get_summary_interval_invalid_json():
+    from server.watcher import SUMMARY_TRIGGER_INTERVAL, _get_summary_interval
+
+    await db.set_setting("summary_interval", "not-a-number")
+    result = await _get_summary_interval()
+    assert result == SUMMARY_TRIGGER_INTERVAL
+
+
+async def test_get_summary_interval_zero():
+    from server.watcher import SUMMARY_TRIGGER_INTERVAL, _get_summary_interval
+
+    await db.set_setting("summary_interval", "0")
+    result = await _get_summary_interval()
+    assert result == SUMMARY_TRIGGER_INTERVAL
+
+
+async def test_get_summary_interval_negative():
+    from server.watcher import SUMMARY_TRIGGER_INTERVAL, _get_summary_interval
+
+    await db.set_setting("summary_interval", "-5")
+    result = await _get_summary_interval()
+    assert result == SUMMARY_TRIGGER_INTERVAL
+
+
+async def test_get_summary_interval_float():
+    from server.watcher import SUMMARY_TRIGGER_INTERVAL, _get_summary_interval
+
+    await db.set_setting("summary_interval", "3.5")
+    result = await _get_summary_interval()
+    assert result == SUMMARY_TRIGGER_INTERVAL
+
+
+# --- AI Summary: _should_generate_summary ---
+
+
+async def test_should_generate_summary_happy_path():
+    import server.watcher as watcher_mod
+    from server.watcher import _should_generate_summary
+
+    watcher_mod._user_message_counts["s1"] = 5
+    watcher_mod._claude_available = True
+    session = {"status": "working", "display_name_locked": False, "parent_session_id": None}
+    assert await _should_generate_summary("s1", session) is True
+    watcher_mod._user_message_counts.pop("s1", None)
+
+
+async def test_should_generate_summary_not_on_threshold():
+    import server.watcher as watcher_mod
+    from server.watcher import _should_generate_summary
+
+    watcher_mod._user_message_counts["s2"] = 3
+    watcher_mod._claude_available = True
+    session = {"status": "working", "display_name_locked": False, "parent_session_id": None}
+    assert await _should_generate_summary("s2", session) is False
+    watcher_mod._user_message_counts.pop("s2", None)
+
+
+async def test_should_generate_summary_locked():
+    import server.watcher as watcher_mod
+    from server.watcher import _should_generate_summary
+
+    watcher_mod._user_message_counts["s3"] = 5
+    watcher_mod._claude_available = True
+    session = {"status": "working", "display_name_locked": True, "parent_session_id": None}
+    assert await _should_generate_summary("s3", session) is False
+    watcher_mod._user_message_counts.pop("s3", None)
+
+
+async def test_should_generate_summary_completed():
+    import server.watcher as watcher_mod
+    from server.watcher import _should_generate_summary
+
+    watcher_mod._user_message_counts["s4"] = 5
+    watcher_mod._claude_available = True
+    session = {"status": "completed", "display_name_locked": False, "parent_session_id": None}
+    assert await _should_generate_summary("s4", session) is False
+    watcher_mod._user_message_counts.pop("s4", None)
+
+
+async def test_should_generate_summary_stale():
+    import server.watcher as watcher_mod
+    from server.watcher import _should_generate_summary
+
+    watcher_mod._user_message_counts["s5"] = 5
+    watcher_mod._claude_available = True
+    session = {"status": "stale", "display_name_locked": False, "parent_session_id": None}
+    assert await _should_generate_summary("s5", session) is False
+    watcher_mod._user_message_counts.pop("s5", None)
+
+
+async def test_should_generate_summary_subagent():
+    import server.watcher as watcher_mod
+    from server.watcher import _should_generate_summary
+
+    watcher_mod._user_message_counts["s6"] = 5
+    watcher_mod._claude_available = True
+    session = {"status": "working", "display_name_locked": False, "parent_session_id": "parent-1"}
+    assert await _should_generate_summary("s6", session) is False
+    watcher_mod._user_message_counts.pop("s6", None)
+
+
+async def test_should_generate_summary_claude_unavailable():
+    import server.watcher as watcher_mod
+    from server.watcher import _should_generate_summary
+
+    watcher_mod._user_message_counts["s7"] = 5
+    watcher_mod._claude_available = False
+    session = {"status": "working", "display_name_locked": False, "parent_session_id": None}
+    assert await _should_generate_summary("s7", session) is False
+    watcher_mod._claude_available = True
+    watcher_mod._user_message_counts.pop("s7", None)
+
+
+async def test_should_generate_summary_no_session():
+    from server.watcher import _should_generate_summary
+
+    assert await _should_generate_summary("s8", None) is False
+
+
+async def test_should_generate_summary_zero_count():
+    import server.watcher as watcher_mod
+    from server.watcher import _should_generate_summary
+
+    watcher_mod._user_message_counts["s9"] = 0
+    watcher_mod._claude_available = True
+    session = {"status": "working", "display_name_locked": False, "parent_session_id": None}
+    assert await _should_generate_summary("s9", session) is False
+    watcher_mod._user_message_counts.pop("s9", None)
+
+
+async def test_should_generate_summary_task_inflight():
+    import server.watcher as watcher_mod
+    from server.watcher import _should_generate_summary
+
+    watcher_mod._user_message_counts["s10"] = 5
+    watcher_mod._claude_available = True
+    mock_task = MagicMock()
+    mock_task.done.return_value = False
+    watcher_mod._summary_tasks["s10"] = mock_task
+    session = {"status": "working", "display_name_locked": False, "parent_session_id": None}
+    assert await _should_generate_summary("s10", session) is False
+    watcher_mod._summary_tasks.pop("s10", None)
+    watcher_mod._user_message_counts.pop("s10", None)
+
+
+# --- AI Summary: _generate_ai_summary ---
+
+
+async def test_generate_ai_summary_success():
+    from server.watcher import _generate_ai_summary
+
+    await db.create_session("gen-1", project_path="/tmp/proj")
+    await db.update_session("gen-1", git_branch="feat/auth", status="working")
+    await db.add_transcript("gen-1", "user", "Fix the auth bug")
+    await db.add_transcript("gen-1", "assistant", "I will fix the JWT validation")
+
+    mock_proc = AsyncMock()
+    mock_proc.returncode = 0
+    mock_proc.communicate.return_value = (
+        b'{"title": "Fix JWT Auth", "ticket_id": "AUTH-99", "pr_url": null}',
+        b"",
+    )
+
+    with (
+        patch("asyncio.create_subprocess_exec", new_callable=AsyncMock, return_value=mock_proc),
+        patch("asyncio.wait_for", new_callable=AsyncMock, return_value=mock_proc.communicate.return_value),
+        patch("server.routes.ws.broadcast_session_update", new_callable=AsyncMock),
+    ):
+        await _generate_ai_summary("gen-1")
+
+    session = await db.get_session("gen-1")
+    assert session["display_name"] == "Fix JWT Auth"
+    assert session["ticket_id"] == "AUTH-99"
+
+
+async def test_generate_ai_summary_does_not_overwrite_existing_ticket():
+    from server.watcher import _generate_ai_summary
+
+    await db.create_session("gen-2", project_path="/tmp/proj")
+    await db.update_session("gen-2", ticket_id="EXISTING-1", status="working")
+    await db.add_transcript("gen-2", "user", "Some work")
+
+    mock_proc = AsyncMock()
+    mock_proc.returncode = 0
+    mock_proc.communicate.return_value = (
+        b'{"title": "New Title", "ticket_id": "OTHER-2", "pr_url": "https://github.com/o/r/pull/5"}',
+        b"",
+    )
+
+    with (
+        patch("asyncio.create_subprocess_exec", new_callable=AsyncMock, return_value=mock_proc),
+        patch("asyncio.wait_for", new_callable=AsyncMock, return_value=mock_proc.communicate.return_value),
+        patch("server.routes.ws.broadcast_session_update", new_callable=AsyncMock),
+    ):
+        await _generate_ai_summary("gen-2")
+
+    session = await db.get_session("gen-2")
+    assert session["display_name"] == "New Title"
+    assert session["ticket_id"] == "EXISTING-1"  # NOT overwritten
+    assert session["pr_url"] == "https://github.com/o/r/pull/5"  # Filled in
+
+
+async def test_generate_ai_summary_locked_session():
+    from server.watcher import _generate_ai_summary
+
+    await db.create_session("gen-3", project_path="/tmp/proj")
+    await db.update_session("gen-3", display_name_locked=1, display_name="Locked Title")
+    await db.add_transcript("gen-3", "user", "Some work")
+
+    with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec:
+        await _generate_ai_summary("gen-3")
+        mock_exec.assert_not_called()
+
+    session = await db.get_session("gen-3")
+    assert session["display_name"] == "Locked Title"
+
+
+async def test_generate_ai_summary_no_conversation():
+    from server.watcher import _generate_ai_summary
+
+    await db.create_session("gen-4", project_path="/tmp/proj")
+    # No transcripts added
+
+    with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec:
+        await _generate_ai_summary("gen-4")
+        mock_exec.assert_not_called()
+
+
+async def test_generate_ai_summary_subprocess_failure():
+    from server.watcher import _generate_ai_summary
+
+    await db.create_session("gen-5", project_path="/tmp/proj")
+    await db.update_session("gen-5", status="working")
+    await db.add_transcript("gen-5", "user", "Do something")
+
+    mock_proc = AsyncMock()
+    mock_proc.returncode = 1
+    mock_proc.communicate.return_value = (b"", b"Error: something went wrong")
+
+    with (
+        patch("asyncio.create_subprocess_exec", new_callable=AsyncMock, return_value=mock_proc),
+        patch("asyncio.wait_for", new_callable=AsyncMock, return_value=mock_proc.communicate.return_value),
+    ):
+        await _generate_ai_summary("gen-5")
+
+    session = await db.get_session("gen-5")
+    assert session["display_name"] is None  # Not updated
+
+
+async def test_generate_ai_summary_invalid_response():
+    from server.watcher import _generate_ai_summary
+
+    await db.create_session("gen-6", project_path="/tmp/proj")
+    await db.update_session("gen-6", status="working")
+    await db.add_transcript("gen-6", "user", "Do something")
+
+    mock_proc = AsyncMock()
+    mock_proc.returncode = 0
+    mock_proc.communicate.return_value = (b"This is not JSON", b"")
+
+    with (
+        patch("asyncio.create_subprocess_exec", new_callable=AsyncMock, return_value=mock_proc),
+        patch("asyncio.wait_for", new_callable=AsyncMock, return_value=mock_proc.communicate.return_value),
+    ):
+        await _generate_ai_summary("gen-6")
+
+    session = await db.get_session("gen-6")
+    assert session["display_name"] is None
+
+
+async def test_generate_ai_summary_timeout():
+    from server.watcher import _generate_ai_summary
+
+    await db.create_session("gen-7", project_path="/tmp/proj")
+    await db.update_session("gen-7", status="working")
+    await db.add_transcript("gen-7", "user", "Do something")
+
+    mock_proc = AsyncMock()
+
+    with (
+        patch("asyncio.create_subprocess_exec", new_callable=AsyncMock, return_value=mock_proc),
+        patch("asyncio.wait_for", new_callable=AsyncMock, side_effect=TimeoutError),
+    ):
+        await _generate_ai_summary("gen-7")  # Should not raise
+
+    session = await db.get_session("gen-7")
+    assert session["display_name"] is None
+
+
+async def test_generate_ai_summary_claude_not_found():
+    import server.watcher as watcher_mod
+    from server.watcher import _generate_ai_summary
+
+    watcher_mod._claude_available = True
+    await db.create_session("gen-8", project_path="/tmp/proj")
+    await db.update_session("gen-8", status="working")
+    await db.add_transcript("gen-8", "user", "Do something")
+
+    with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock, side_effect=FileNotFoundError):
+        await _generate_ai_summary("gen-8")
+
+    assert watcher_mod._claude_available is False
+    watcher_mod._claude_available = True
+
+
+async def test_generate_ai_summary_locked_during_subprocess():
+    """If title gets locked while subprocess runs, update should be skipped."""
+    from server.watcher import _generate_ai_summary
+
+    await db.create_session("gen-9", project_path="/tmp/proj")
+    await db.update_session("gen-9", status="working")
+    await db.add_transcript("gen-9", "user", "Do something")
+
+    mock_proc = AsyncMock()
+    mock_proc.returncode = 0
+    mock_proc.communicate.return_value = (
+        b'{"title": "New Title", "ticket_id": null, "pr_url": null}',
+        b"",
+    )
+
+    call_count = 0
+
+    async def fake_wait_for(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        # Simulate user locking the title while subprocess was running
+        await db.update_session("gen-9", display_name_locked=1, display_name="User Title")
+        return mock_proc.communicate.return_value
+
+    with (
+        patch("asyncio.create_subprocess_exec", new_callable=AsyncMock, return_value=mock_proc),
+        patch("asyncio.wait_for", side_effect=fake_wait_for),
+        patch("server.routes.ws.broadcast_session_update", new_callable=AsyncMock),
+    ):
+        await _generate_ai_summary("gen-9")
+
+    session = await db.get_session("gen-9")
+    assert session["display_name"] == "User Title"  # Not overwritten
+
+
+async def test_generate_ai_summary_cleans_up_task():
+    """Summary task should be removed from _summary_tasks when complete."""
+    import server.watcher as watcher_mod
+    from server.watcher import _generate_ai_summary
+
+    await db.create_session("gen-10", project_path="/tmp/proj")
+    await db.update_session("gen-10", status="working")
+    await db.add_transcript("gen-10", "user", "Do something")
+    watcher_mod._summary_tasks["gen-10"] = MagicMock()
+
+    mock_proc = AsyncMock()
+    mock_proc.returncode = 0
+    mock_proc.communicate.return_value = (
+        b'{"title": "Done", "ticket_id": null, "pr_url": null}',
+        b"",
+    )
+
+    with (
+        patch("asyncio.create_subprocess_exec", new_callable=AsyncMock, return_value=mock_proc),
+        patch("asyncio.wait_for", new_callable=AsyncMock, return_value=mock_proc.communicate.return_value),
+        patch("server.routes.ws.broadcast_session_update", new_callable=AsyncMock),
+    ):
+        await _generate_ai_summary("gen-10")
+
+    assert "gen-10" not in watcher_mod._summary_tasks
+
+
+# --- AI Summary: counting in _process_file_changes ---
+
+
+async def test_process_file_counts_user_messages_for_summary():
+    """User message counting should trigger summary at threshold."""
+    import server.watcher as watcher_mod
+
+    watcher_mod._user_message_counts.clear()
+    watcher_mod._claude_available = True
+
+    lines = []
+    for i in range(5):
+        lines.append(
+            json.dumps(
+                {
+                    "type": "user",
+                    "message": {"role": "user", "content": f"Message number {i + 1} from the user"},
+                }
+            )
+        )
+        lines.append(
+            json.dumps(
+                {
+                    "type": "assistant",
+                    "message": {"role": "assistant", "content": f"Reply {i + 1}"},
+                }
+            )
+        )
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False, dir=tempfile.gettempdir()) as f:
+        f.write("\n".join(lines) + "\n")
+        tmp_path = f.name
+
+    session_id = os.path.splitext(os.path.basename(tmp_path))[0]
+
+    try:
+        with (
+            patch("server.routes.ws.broadcast_session_update", new_callable=AsyncMock),
+            patch("server.watcher._generate_ai_summary", new_callable=AsyncMock) as mock_gen,
+        ):
+            await _process_file_changes(tmp_path)
+
+        assert watcher_mod._user_message_counts[session_id] == 5
+        mock_gen.assert_called_once_with(session_id)
+    finally:
+        os.unlink(tmp_path)
+        watcher_mod._user_message_counts.pop(session_id, None)
+
+
+async def test_process_file_no_summary_below_threshold():
+    """Summary should not trigger below the threshold."""
+    import server.watcher as watcher_mod
+
+    watcher_mod._user_message_counts.clear()
+    watcher_mod._claude_available = True
+
+    lines = []
+    for i in range(3):
+        lines.append(
+            json.dumps(
+                {
+                    "type": "user",
+                    "message": {"role": "user", "content": f"Message {i + 1} here"},
+                }
+            )
+        )
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False, dir=tempfile.gettempdir()) as f:
+        f.write("\n".join(lines) + "\n")
+        tmp_path = f.name
+
+    session_id = os.path.splitext(os.path.basename(tmp_path))[0]
+
+    try:
+        with (
+            patch("server.routes.ws.broadcast_session_update", new_callable=AsyncMock),
+            patch("server.watcher._generate_ai_summary", new_callable=AsyncMock) as mock_gen,
+        ):
+            await _process_file_changes(tmp_path)
+
+        assert watcher_mod._user_message_counts[session_id] == 3
+        mock_gen.assert_not_called()
+    finally:
+        os.unlink(tmp_path)
+        watcher_mod._user_message_counts.pop(session_id, None)
+
+
+# --- stop_watcher cleans up summary state ---
+
+
+def test_stop_watcher_cleans_up_summary_tasks():
+    import server.watcher as watcher_mod
+    from server.watcher import stop_watcher
+
+    watcher_mod._watcher_task = None
+
+    mock_summary = MagicMock()
+    mock_summary.done.return_value = False
+    watcher_mod._summary_tasks["test-sess"] = mock_summary
+    watcher_mod._user_message_counts["test-sess"] = 10
+
+    stop_watcher()
+
+    mock_summary.cancel.assert_called_once()
+    assert len(watcher_mod._summary_tasks) == 0
+    assert len(watcher_mod._user_message_counts) == 0


### PR DESCRIPTION
## Summary
- **Expanded view toggle**: "Expanded" button in the topbar switches all tiles to show last 5 transcript entries inline (no chevron). Grid widens in expanded mode. State persists via localStorage.
- **AI session summaries**: Every N user messages (default 5, configurable), runs `claude -p` in the background to generate an evolving 3-8 word session title. Respects title lock, disables gracefully if `claude` CLI is unavailable.
- **Manual rename auto-locks**: Editing a session title now sets `display_name_locked: true` so AI summaries don't overwrite user renames.
- **Settings UI**: New "AI Summaries" tab with configurable interval.

Closes #16

## Test plan
- [x] Open dashboard, click "Expanded" button — tiles show last 5 transcript lines inline
- [x] Toggle off — compact view returns with chevron-based preview
- [x] Refresh page — expanded state persists
- [x] Start a Claude Code session, send 5+ user messages — verify title updates in server logs and on dashboard
- [x] Manually rename a session — verify lock icon activates and AI does not overwrite
- [x] Open Settings > AI Summaries — change interval, save, verify it persists
- [x] `make check` passes (ruff, mypy, pytest — 256 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)