### PR TITLE
feat: configurable expanded tile transcript item count

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -429,7 +429,7 @@ body {
   border-radius: var(--radius);
   border-left: 2px solid var(--accent);
   font-size: 11px;
-  max-height: 200px;
+  max-height: 380px;
   overflow-y: auto;
 }
 

--- a/public/index.html
+++ b/public/index.html
@@ -94,6 +94,7 @@
           <div class="settings-sidebar">
             <button class="settings-tab active" data-tab="integrations">&#128279; Integrations</button>
             <button class="settings-tab" data-tab="summaries">&#9881; AI Summaries</button>
+            <button class="settings-tab" data-tab="dashboard">&#9638; Dashboard</button>
           </div>
           <div class="settings-content">
             <div class="settings-panel active" id="tab-integrations">
@@ -118,6 +119,16 @@
                   <label for="summary-interval">Update title every N user messages</label>
                   <input type="number" class="input" id="summary-interval" min="1" max="100" value="5" />
                   <small class="form-hint">Runs <code>claude -p</code> in the background to generate an evolving session title. Set to a higher number to reduce frequency. Requires the <code>claude</code> CLI to be available.</small>
+                </div>
+              </div>
+            </div>
+            <div class="settings-panel" id="tab-dashboard">
+              <div class="settings-section">
+                <div class="section-title">Expanded View</div>
+                <div class="form-group">
+                  <label for="expanded-tile-items">Transcript items per tile</label>
+                  <input type="number" class="input" id="expanded-tile-items" min="1" max="50" value="5" />
+                  <small class="form-hint">Number of recent transcript messages shown in each expanded tile.</small>
                 </div>
               </div>
             </div>

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -150,6 +150,7 @@ const App = {
         const data = await resp.json();
         this.settings = data.settings || {};
         closeModal();
+        Dashboard.render(this.sessions);
       } catch (e) {
         console.error('Failed to save settings:', e);
         indicator.textContent = 'Failed to save';

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -107,6 +107,7 @@ const App = {
       document.getElementById('jira-keys').value = keys.join(', ');
       document.getElementById('jira-url').value = this.settings.jira_server_url || '';
       document.getElementById('summary-interval').value = this.settings.summary_interval || 5;
+      document.getElementById('expanded-tile-items').value = this.settings.expanded_tile_items || 5;
       indicator.textContent = '';
       indicator.className = 'save-indicator';
       modal.style.display = 'flex';
@@ -134,6 +135,7 @@ const App = {
       const keys = keysRaw.split(',').map(k => k.trim().toUpperCase()).filter(Boolean);
       const url = document.getElementById('jira-url').value.trim();
       const summaryInterval = parseInt(document.getElementById('summary-interval').value, 10) || 5;
+      const expandedTileItems = parseInt(document.getElementById('expanded-tile-items').value, 10) || 5;
       try {
         const resp = await fetch('/api/settings', {
           method: 'PUT',
@@ -142,13 +144,12 @@ const App = {
             jira_project_keys: keys,
             jira_server_url: url || null,
             summary_interval: summaryInterval,
+            expanded_tile_items: expandedTileItems,
           }),
         });
         const data = await resp.json();
         this.settings = data.settings || {};
-        indicator.textContent = 'Settings saved';
-        indicator.className = 'save-indicator saved';
-        setTimeout(() => { indicator.textContent = ''; indicator.className = 'save-indicator'; }, 2000);
+        closeModal();
       } catch (e) {
         console.error('Failed to save settings:', e);
         indicator.textContent = 'Failed to save';

--- a/public/js/dashboard.js
+++ b/public/js/dashboard.js
@@ -430,7 +430,8 @@ const Dashboard = {
     const container = document.getElementById(`expanded-preview-${sessionId}`);
     if (!container) return;
     try {
-      const resp = await fetch(`/api/sessions/${sessionId}/transcript?limit=5`);
+      const limit = (App.settings && App.settings.expanded_tile_items) || 5;
+      const resp = await fetch(`/api/sessions/${sessionId}/transcript?limit=${limit}`);
       const data = await resp.json();
       const msgs = data.transcripts || [];
       if (msgs.length === 0) {

--- a/server/routes/api.py
+++ b/server/routes/api.py
@@ -41,6 +41,7 @@ class SettingsUpdate(BaseModel):
     jira_project_keys: list[str] | None = None
     jira_server_url: str | None = None
     summary_interval: int | None = None
+    expanded_tile_items: int | None = None
 
 
 _UNSET = object()
@@ -163,6 +164,10 @@ async def update_settings(req: SettingsUpdate):
         if req.summary_interval < 1:
             raise HTTPException(status_code=400, detail="summary_interval must be >= 1")
         await db.set_setting("summary_interval", json.dumps(req.summary_interval))
+    if req.expanded_tile_items is not None:
+        if req.expanded_tile_items < 1:
+            raise HTTPException(status_code=400, detail="expanded_tile_items must be >= 1")
+        await db.set_setting("expanded_tile_items", json.dumps(req.expanded_tile_items))
     return await get_settings()
 
 

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -224,6 +224,32 @@ async def test_update_settings_summary_interval_negative(client: AsyncClient):
     assert resp.status_code == 400
 
 
+async def test_update_settings_expanded_tile_items(client: AsyncClient):
+    resp = await client.put(
+        "/api/settings",
+        json={"expanded_tile_items": 15},
+    )
+    assert resp.status_code == 200
+    settings = resp.json()["settings"]
+    assert settings["expanded_tile_items"] == 15
+
+
+async def test_update_settings_expanded_tile_items_invalid(client: AsyncClient):
+    resp = await client.put(
+        "/api/settings",
+        json={"expanded_tile_items": 0},
+    )
+    assert resp.status_code == 400
+
+
+async def test_update_settings_expanded_tile_items_negative(client: AsyncClient):
+    resp = await client.put(
+        "/api/settings",
+        json={"expanded_tile_items": -1},
+    )
+    assert resp.status_code == 400
+
+
 async def test_get_settings_with_values(client: AsyncClient):
     await db.set_setting("jira_project_keys", '["PROJ"]')
     await db.set_setting("plain_key", "not-json")

--- a/tests/unit/test_hooks.py
+++ b/tests/unit/test_hooks.py
@@ -1025,3 +1025,175 @@ async def test_stale_checker_logs_warning_for_long_waiting():
 
     mock_logger.warning.assert_called_once()
     assert "stale-warn-1" in mock_logger.warning.call_args[0][1]
+
+
+async def test_check_stale_subagents_marks_completed():
+    """_check_stale_subagents should mark inactive subagents as completed."""
+    from server.hooks import _check_stale_subagents
+
+    old_time = (datetime.now(UTC) - timedelta(minutes=10)).isoformat()
+    await db.create_session("parent-sub-stale")
+    await db.update_session("parent-sub-stale", status="working")
+    await db.create_session("sub-stale-1")
+    await db.update_session(
+        "sub-stale-1",
+        parent_session_id="parent-sub-stale",
+        status="working",
+        last_activity_at=old_time,
+    )
+
+    with patch("server.hooks._on_session_update", new=None):
+        await _check_stale_subagents(datetime.now(UTC))
+
+    sub = await db.get_session("sub-stale-1")
+    assert sub["status"] == "completed"
+    assert sub["ended_at"] is not None
+
+
+async def test_check_stale_subagents_skips_recent():
+    """_check_stale_subagents should not touch recently active subagents."""
+    from server.hooks import _check_stale_subagents
+
+    recent_time = datetime.now(UTC).isoformat()
+    await db.create_session("parent-sub-recent")
+    await db.create_session("sub-recent-1")
+    await db.update_session(
+        "sub-recent-1",
+        parent_session_id="parent-sub-recent",
+        status="working",
+        last_activity_at=recent_time,
+    )
+
+    await _check_stale_subagents(datetime.now(UTC))
+
+    sub = await db.get_session("sub-recent-1")
+    assert sub["status"] == "working"
+
+
+async def test_check_stale_subagents_broadcasts_parent():
+    """_check_stale_subagents should broadcast parent update when subagent completes."""
+    from server.hooks import _check_stale_subagents, set_update_callback
+
+    old_time = (datetime.now(UTC) - timedelta(minutes=10)).isoformat()
+    await db.create_session("parent-sub-bc")
+    await db.update_session("parent-sub-bc", status="working")
+    await db.create_session("sub-bc-1")
+    await db.update_session(
+        "sub-bc-1",
+        parent_session_id="parent-sub-bc",
+        status="working",
+        last_activity_at=old_time,
+    )
+
+    callback = AsyncMock()
+    set_update_callback(callback)
+
+    try:
+        await _check_stale_subagents(datetime.now(UTC))
+        assert callback.call_count >= 1
+        # The parent session should have been broadcast
+        updated_session = callback.call_args[0][0]
+        assert updated_session["id"] == "parent-sub-bc"
+        assert "subagents" in updated_session
+    finally:
+        set_update_callback(None)
+
+
+async def test_check_stale_subagents_no_last_activity():
+    """_check_stale_subagents should skip subagents without last_activity_at."""
+    from server.hooks import _check_stale_subagents
+
+    await db.create_session("parent-sub-nola")
+    await db.create_session("sub-nola-1")
+    await db.update_session(
+        "sub-nola-1",
+        parent_session_id="parent-sub-nola",
+        status="working",
+        last_activity_at=None,
+    )
+
+    # Verify last_activity_at is actually None
+    sub_before = await db.get_session("sub-nola-1")
+    assert sub_before["last_activity_at"] is None
+
+    await _check_stale_subagents(datetime.now(UTC))
+
+    sub = await db.get_session("sub-nola-1")
+    assert sub["status"] == "working"
+
+
+async def test_check_stale_subagents_timezone_naive():
+    """_check_stale_subagents should handle timezone-naive timestamps."""
+    from server.hooks import _check_stale_subagents
+
+    # Use a naive timestamp (no timezone info) that is old enough to be stale
+    old_naive = (datetime.now(UTC) - timedelta(minutes=10)).strftime("%Y-%m-%dT%H:%M:%S")
+    await db.create_session("parent-sub-naive")
+    await db.update_session("parent-sub-naive", status="working")
+    await db.create_session("sub-naive-1")
+    await db.update_session(
+        "sub-naive-1",
+        parent_session_id="parent-sub-naive",
+        status="working",
+        last_activity_at=old_naive,
+    )
+
+    with patch("server.hooks._on_session_update", new=None):
+        await _check_stale_subagents(datetime.now(UTC))
+
+    sub = await db.get_session("sub-naive-1")
+    assert sub["status"] == "completed"
+
+
+async def test_check_stale_subagents_invalid_timestamp():
+    """_check_stale_subagents should handle invalid timestamps gracefully."""
+    from server.hooks import _check_stale_subagents
+
+    await db.create_session("parent-sub-bad")
+    await db.create_session("sub-bad-ts")
+    await db.update_session(
+        "sub-bad-ts",
+        parent_session_id="parent-sub-bad",
+        status="working",
+        last_activity_at="not-a-timestamp",
+    )
+
+    # Should not crash
+    await _check_stale_subagents(datetime.now(UTC))
+
+    sub = await db.get_session("sub-bad-ts")
+    assert sub["status"] == "working"
+
+
+async def test_check_stale_sessions_skips_working_subagent():
+    """_check_stale_sessions should not mark a session stale if it has working subagents."""
+    import server.hooks as hooks_mod
+    from server.hooks import _check_stale_sessions
+
+    old_time = (datetime.now(UTC) - timedelta(minutes=10)).isoformat()
+    await db.create_session("parent-with-sub")
+    await db.update_session("parent-with-sub", status="working", last_activity_at=old_time)
+    await db.create_session("sub-active-1")
+    await db.update_session(
+        "sub-active-1",
+        parent_session_id="parent-with-sub",
+        status="working",
+        last_activity_at=datetime.now(UTC).isoformat(),
+    )
+
+    call_count = 0
+
+    async def mock_sleep(seconds):
+        nonlocal call_count
+        call_count += 1
+        if call_count > 1:
+            raise asyncio.CancelledError()
+
+    with patch("asyncio.sleep", side_effect=mock_sleep), patch.object(hooks_mod, "_on_session_update", new=None):
+        try:
+            await _check_stale_sessions()
+        except asyncio.CancelledError:
+            pass
+
+    parent = await db.get_session("parent-with-sub")
+    assert parent["status"] == "working"

--- a/tests/unit/test_watcher.py
+++ b/tests/unit/test_watcher.py
@@ -2126,3 +2126,131 @@ def test_stop_watcher_cleans_up_summary_tasks():
     mock_summary.cancel.assert_called_once()
     assert len(watcher_mod._summary_tasks) == 0
     assert len(watcher_mod._user_message_counts) == 0
+
+
+# --- Additional coverage tests ---
+
+
+def test_extract_activity_preview_tool_no_summary():
+    """Tool match with empty summary should return just the verb."""
+    entry = {
+        "role": "assistant",
+        "content": "[Tool: Read]\n",
+    }
+    result = _extract_activity_preview([entry])
+    assert result == "Reading"
+
+
+def test_extract_activity_preview_tool_no_summary_whitespace():
+    """Tool match with whitespace-only summary should return just the verb."""
+    entry = {
+        "role": "assistant",
+        "content": "[Tool: Grep]\n   \n",
+    }
+    result = _extract_activity_preview([entry])
+    assert result == "Searching"
+
+
+async def test_process_file_subagent_keeps_parent_alive():
+    """Subagent activity should revive a stale parent session."""
+    from datetime import UTC, datetime
+
+    # Create parent in stale state
+    await db.create_session("parent-alive-1")
+    await db.update_session("parent-alive-1", status="stale")
+
+    # Create subagent linked to parent
+    await db.create_session("sub-alive-1")
+    await db.update_session("sub-alive-1", parent_session_id="parent-alive-1", status="working")
+
+    # Create a JSONL file at a subagent path
+    parent_dir = tempfile.mkdtemp()
+    subagent_dir = os.path.join(parent_dir, "parent-alive-1", "subagents")
+    os.makedirs(subagent_dir)
+    jsonl_path = os.path.join(subagent_dir, "sub-alive-1.jsonl")
+    with open(jsonl_path, "w") as f:
+        f.write(
+            json.dumps(
+                {
+                    "type": "assistant",
+                    "message": {
+                        "role": "assistant",
+                        "content": "[Tool: Read]\n/some/file.py",
+                    },
+                    "timestamp": datetime.now(UTC).isoformat(),
+                }
+            )
+            + "\n"
+        )
+
+    try:
+        with patch("server.routes.ws.broadcast_session_update", new_callable=AsyncMock):
+            await _process_file_changes(jsonl_path)
+
+        parent = await db.get_session("parent-alive-1")
+        assert parent["status"] == "working"
+    finally:
+        import shutil
+
+        shutil.rmtree(parent_dir)
+
+
+async def test_process_file_revives_stale_session_without_tools():
+    """A stale session receiving non-tool entries should revive to idle."""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False, dir=tempfile.gettempdir()) as f:
+        f.write(
+            json.dumps(
+                {
+                    "type": "assistant",
+                    "message": {"role": "assistant", "content": "Let me help you with that."},
+                    "timestamp": "2026-03-30T12:00:00Z",
+                }
+            )
+            + "\n"
+        )
+        tmp_path = f.name
+
+    session_id = os.path.splitext(os.path.basename(tmp_path))[0]
+    await db.create_session(session_id)
+    await db.update_session(session_id, status="stale")
+
+    try:
+        with patch("server.routes.ws.broadcast_session_update", new_callable=AsyncMock):
+            await _process_file_changes(tmp_path)
+
+        session = await db.get_session(session_id)
+        assert session["status"] == "idle"
+    finally:
+        os.unlink(tmp_path)
+
+
+async def test_process_file_new_subagent_creates_with_parent():
+    """When a JSONL file exists at a subagent path but no session exists yet, it should be created with parent."""
+    parent_dir = tempfile.mkdtemp()
+    subagent_dir = os.path.join(parent_dir, "parent-new-sub", "subagents")
+    os.makedirs(subagent_dir)
+    jsonl_path = os.path.join(subagent_dir, "new-sub-1.jsonl")
+    with open(jsonl_path, "w") as f:
+        f.write(
+            json.dumps(
+                {
+                    "type": "assistant",
+                    "message": {"role": "assistant", "content": "Working on subtask"},
+                    "timestamp": "2026-03-30T12:00:00Z",
+                }
+            )
+            + "\n"
+        )
+
+    try:
+        with patch("server.routes.ws.broadcast_session_update", new_callable=AsyncMock):
+            await _process_file_changes(jsonl_path)
+
+        session = await db.get_session("new-sub-1")
+        assert session is not None
+        assert session["parent_session_id"] == "parent-new-sub"
+        assert session["status"] == "working"
+    finally:
+        import shutil
+
+        shutil.rmtree(parent_dir)


### PR DESCRIPTION
## Summary
- Add a **Dashboard** settings tab with a "Transcript items per tile" option (1–50, default 5) so users can control how many transcript messages appear in expanded tiles
- Persist the setting via the existing `/api/settings` API with backend validation
- Close the settings modal on successful save instead of showing a temporary indicator

## Test plan
- [x] Open Settings, verify the new "Dashboard" tab appears
- [x] Change "Transcript items per tile" to a different value and save
- [x] Confirm the modal closes on save
- [x] Toggle expanded view and verify tiles show the configured number of transcript items
- [x] Verify `make check` passes (lint, format, types, tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)