### PR TITLE
chore: change default port from 3000 to 3010

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -14,7 +14,7 @@ Claude Code fires a hook event (e.g. "I just used the Read tool")
 hook-handler.py receives the event JSON on stdin
         |
         v
-hook-handler.py POSTs it to http://localhost:3000/api/hooks
+hook-handler.py POSTs it to http://localhost:3010/api/hooks
         |
         v
 The server updates the SQLite DB and broadcasts via WebSocket
@@ -54,7 +54,7 @@ Critical design constraint: **it must never block Claude Code.** If the server i
 
 ### 3. The Server (`server/`)
 
-A FastAPI app running on port 3000. It does four things:
+A FastAPI app running on port 3010. It does four things:
 
 | Component | File | What It Does |
 |-----------|------|-------------|

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ Web-based dashboard for monitoring and managing multiple Claude Code sessions.
 ## Running
 ```bash
 source .venv/bin/activate
-uvicorn server.main:app --port 3000 --reload
+uvicorn server.main:app --port 3010 --reload
 ```
 
 ## Testing

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .DEFAULT_GOAL := help
-PORT := 3000
+PORT := 3010
 # Prefer project .venv via uv so `make up` works without `source .venv/bin/activate`
 UV_RUN := uv run
 
@@ -16,7 +16,7 @@ setup install: ## Full local setup: uv venv + dev deps, Playwright Chromium, Cla
 	@echo "Setup complete. Start the app:  make up"
 	@echo "If Playwright/e2e fails (missing OS libs), run:  uv run python -m playwright install --with-deps chromium"
 
-up: ## Start the server (port 3000; override with PORT=3001)
+up: ## Start the server (port 3010; override with PORT=3011)
 	$(UV_RUN) uvicorn server.main:app --port $(PORT) --reload
 
 down: ## Stop the server

--- a/README.md
+++ b/README.md
@@ -51,15 +51,15 @@ pip install .
 bash scripts/setup.sh
 
 # Start the server
-uvicorn server.main:app --port 3000
+uvicorn server.main:app --port 3010
 ```
 
-Then open **http://localhost:3000** in your browser.
+Then open **http://localhost:3010** in your browser.
 
 ## Architecture
 
 ```
-Browser (localhost:3000)
+Browser (localhost:3010)
   |
   |-- REST API (/api/*)      -- Sessions, history, search, analytics
   |-- WebSocket (/ws/*)      -- Real-time dashboard updates
@@ -122,7 +122,7 @@ source .venv/bin/activate
 pytest
 
 # Run with auto-reload
-uvicorn server.main:app --port 3000 --reload
+uvicorn server.main:app --port 3010 --reload
 ```
 
 ## Uninstalling

--- a/scripts/hook-handler.py
+++ b/scripts/hook-handler.py
@@ -10,7 +10,7 @@ import sys
 import urllib.error
 import urllib.request
 
-SERVER_URL = "http://localhost:3000/api/hooks"
+SERVER_URL = "http://localhost:3010/api/hooks"
 TIMEOUT = 5
 
 


### PR DESCRIPTION
## Summary
- Move default server port from 3000 → 3010 to avoid colliding with common Vite/CRA dev servers
- When the dashboard isn't running but a frontend dev server is, `hook-handler.py` POSTs to `/api/hooks` land in the dev server's API proxy and spam its log with 404s
- Updates the hardcoded `SERVER_URL` in `scripts/hook-handler.py`, the `Makefile` default (still overridable via `PORT=...`), and the docs that quote the port

## Test plan
- [ ] `make up` starts on 3010 by default
- [ ] `make up PORT=3000` still works as an override
- [ ] With the dashboard stopped, `hook-handler.py` exits silently (no Claude Code disruption) — its 5s urllib timeout against the unbound port still returns within budget
- [ ] With the dashboard running on 3010, hook events still flow end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)